### PR TITLE
Add payment status fields and seed demo orders

### DIFF
--- a/app/Models/Almacen.php
+++ b/app/Models/Almacen.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Almacen extends Model
 {
+    use HasFactory;
+
     protected $table = 'almacenes';
     protected $fillable = ['nombre', 'direccion'];
 

--- a/app/Models/Categoria.php
+++ b/app/Models/Categoria.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Categoria extends Model
 {
+    use HasFactory;
+
     protected $table = 'categorias';
 
     public function productos()

--- a/app/Models/Cobro.php
+++ b/app/Models/Cobro.php
@@ -2,11 +2,58 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Cobro extends Model
 {
+    use HasFactory;
+
+    public const ESTADO_PAGO_PENDIENTE = 'pendiente';
+    public const ESTADO_PAGO_POR_COBRAR = 'por_cobrar';
+    public const ESTADO_PAGO_VUELTO = 'vuelto';
+    public const ESTADO_PAGO_PAGADO = 'pagado';
+
+    public const ESTADOS_PAGO = [
+        self::ESTADO_PAGO_PENDIENTE,
+        self::ESTADO_PAGO_POR_COBRAR,
+        self::ESTADO_PAGO_VUELTO,
+        self::ESTADO_PAGO_PAGADO,
+    ];
+
+    public const TIPO_PAGO_EFECTIVO = 'efectivo';
+    public const TIPO_PAGO_YAPE = 'yape';
+    public const TIPO_PAGO_PLIN = 'plin';
+    public const TIPO_PAGO_BCP = 'bcp';
+    public const TIPO_PAGO_INTERBANK = 'interbank';
+    public const TIPO_PAGO_BBVA = 'bbva';
+
+    public const TIPOS_PAGO = [
+        self::TIPO_PAGO_EFECTIVO,
+        self::TIPO_PAGO_YAPE,
+        self::TIPO_PAGO_PLIN,
+        self::TIPO_PAGO_BCP,
+        self::TIPO_PAGO_INTERBANK,
+        self::TIPO_PAGO_BBVA,
+    ];
+
     protected $table = 'cobros';
+
+    protected $fillable = [
+        'pedido_id',
+        'monto',
+        'monto_pagado',
+        'tipo_pago',
+        'estado_pago',
+        'metodo',
+        'registrado_por',
+        'observaciones',
+    ];
+
+    protected $casts = [
+        'monto' => 'decimal:2',
+        'monto_pagado' => 'decimal:2',
+    ];
 
     public function pedido()
     {
@@ -16,5 +63,36 @@ class Cobro extends Model
     public function registradoPor()
     {
         return $this->belongsTo(User::class, 'registrado_por');
+    }
+
+    public function scopePendientes($query)
+    {
+        return $query->where('estado_pago', self::ESTADO_PAGO_PENDIENTE);
+    }
+
+    public function scopePagados($query)
+    {
+        return $query->where('estado_pago', self::ESTADO_PAGO_PAGADO);
+    }
+
+    public function scopeConTipoPago($query, string $tipo)
+    {
+        return $query->where('tipo_pago', $tipo);
+    }
+
+    public function getEsParcialAttribute(): bool
+    {
+        $monto = (float) $this->monto;
+        $pagado = (float) $this->monto_pagado;
+
+        return $pagado > 0 && $pagado < $monto;
+    }
+
+    public function getSaldoPendienteAttribute(): float
+    {
+        $monto = (float) $this->monto;
+        $pagado = (float) $this->monto_pagado;
+
+        return round($monto - $pagado, 2);
     }
 }

--- a/app/Models/DetallePedido.php
+++ b/app/Models/DetallePedido.php
@@ -2,11 +2,49 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class DetallePedido extends Model
 {
+    use HasFactory;
+
+    public const UNIDAD_PIEZA = 'pieza';
+    public const UNIDAD_CAJA = 'caja';
+    public const UNIDAD_KG = 'kg';
+    public const UNIDAD_METRO = 'mtr';
+    public const UNIDAD_JUEGO = 'juego';
+    public const UNIDAD_KIT = 'kit';
+
+    public const UNIDADES = [
+        self::UNIDAD_PIEZA,
+        self::UNIDAD_CAJA,
+        self::UNIDAD_KG,
+        self::UNIDAD_METRO,
+        self::UNIDAD_JUEGO,
+        self::UNIDAD_KIT,
+    ];
+
     protected $table = 'detalle_pedido';
+
+    protected $fillable = [
+        'pedido_id',
+        'producto_id',
+        'cantidad',
+        'unidad',
+        'metraje',
+        'precio_unitario',
+        'precio_final',
+        'subtotal',
+    ];
+
+    protected $casts = [
+        'cantidad' => 'decimal:2',
+        'metraje' => 'decimal:2',
+        'precio_unitario' => 'decimal:2',
+        'precio_final' => 'decimal:2',
+        'subtotal' => 'decimal:2',
+    ];
 
     public function pedido()
     {
@@ -16,5 +54,23 @@ class DetallePedido extends Model
     public function producto()
     {
         return $this->belongsTo(Producto::class);
+    }
+
+    public function scopeConUnidad($query, string $unidad)
+    {
+        return $query->where('unidad', $unidad);
+    }
+
+    public function scopeConMetraje($query)
+    {
+        return $query->whereNotNull('metraje');
+    }
+
+    public function getImporteTotalAttribute(): float
+    {
+        $cantidad = (float) $this->cantidad;
+        $precio = (float) ($this->precio_unitario ?? $this->precio_final);
+
+        return round($cantidad * $precio, 2);
     }
 }

--- a/app/Models/Pedido.php
+++ b/app/Models/Pedido.php
@@ -2,11 +2,95 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Pedido extends Model
 {
+    use HasFactory;
+
+    public const ESTADO_PAGO_PENDIENTE = 'pendiente';
+    public const ESTADO_PAGO_POR_COBRAR = 'por_cobrar';
+    public const ESTADO_PAGO_VUELTO = 'vuelto';
+    public const ESTADO_PAGO_PAGADO = 'pagado';
+
+    public const ESTADOS_PAGO = [
+        self::ESTADO_PAGO_PENDIENTE,
+        self::ESTADO_PAGO_POR_COBRAR,
+        self::ESTADO_PAGO_VUELTO,
+        self::ESTADO_PAGO_PAGADO,
+    ];
+
+    public const ESTADO_PEDIDO_PENDIENTE = 'pendiente';
+    public const ESTADO_PEDIDO_EN_CURSO = 'en_curso';
+    public const ESTADO_PEDIDO_ENTREGADO = 'entregado';
+    public const ESTADO_PEDIDO_ANULADO = 'anulado';
+
+    public const ESTADOS_PEDIDO = [
+        self::ESTADO_PEDIDO_PENDIENTE,
+        self::ESTADO_PEDIDO_EN_CURSO,
+        self::ESTADO_PEDIDO_ENTREGADO,
+        self::ESTADO_PEDIDO_ANULADO,
+    ];
+
+    public const TIPO_ENTREGA_RECOJO = 'recojo_almacen';
+    public const TIPO_ENTREGA_ENVIO_TIENDA = 'envio_tienda';
+    public const TIPO_ENTREGA_DELIVERY_CLIENTE = 'delivery_cliente';
+
+    public const TIPOS_ENTREGA = [
+        self::TIPO_ENTREGA_RECOJO,
+        self::TIPO_ENTREGA_ENVIO_TIENDA,
+        self::TIPO_ENTREGA_DELIVERY_CLIENTE,
+    ];
+
+    public const TIPO_PAGO_EFECTIVO = 'efectivo';
+    public const TIPO_PAGO_YAPE = 'yape';
+    public const TIPO_PAGO_PLIN = 'plin';
+    public const TIPO_PAGO_BCP = 'bcp';
+    public const TIPO_PAGO_INTERBANK = 'interbank';
+    public const TIPO_PAGO_BBVA = 'bbva';
+
+    public const TIPOS_PAGO = [
+        self::TIPO_PAGO_EFECTIVO,
+        self::TIPO_PAGO_YAPE,
+        self::TIPO_PAGO_PLIN,
+        self::TIPO_PAGO_BCP,
+        self::TIPO_PAGO_INTERBANK,
+        self::TIPO_PAGO_BBVA,
+    ];
+
     protected $table = 'pedidos';
+
+    protected $fillable = [
+        'tienda_id',
+        'vendedor_id',
+        'almacen_id',
+        'almacen_destino_id',
+        'encargado_id',
+        'monto_total',
+        'monto_pagado',
+        'saldo_pendiente',
+        'metraje_total',
+        'cantidad_total',
+        'unidad_referencia',
+        'precio_promedio',
+        'tipo_entrega',
+        'tipo_pago',
+        'estado_pago',
+        'estado_pedido',
+        'cobra_almacen',
+        'notas',
+    ];
+
+    protected $casts = [
+        'monto_total' => 'decimal:2',
+        'monto_pagado' => 'decimal:2',
+        'saldo_pendiente' => 'decimal:2',
+        'metraje_total' => 'decimal:2',
+        'cantidad_total' => 'decimal:2',
+        'precio_promedio' => 'decimal:2',
+        'cobra_almacen' => 'boolean',
+    ];
 
     public function tienda()
     {
@@ -23,6 +107,11 @@ class Pedido extends Model
         return $this->belongsTo(Almacen::class);
     }
 
+    public function almacenDestino()
+    {
+        return $this->belongsTo(Almacen::class, 'almacen_destino_id');
+    }
+
     public function encargado()
     {
         return $this->belongsTo(User::class, 'encargado_id');
@@ -36,5 +125,33 @@ class Pedido extends Model
     public function cobros()
     {
         return $this->hasMany(Cobro::class);
+    }
+
+    public function scopeConPagosPendientes($query)
+    {
+        return $query->whereColumn('monto_pagado', '<', 'monto_total');
+    }
+
+    public function scopeConPagosCompletos($query)
+    {
+        return $query->whereColumn('monto_pagado', '>=', 'monto_total');
+    }
+
+    public function scopeConEstadoPago($query, string $estado)
+    {
+        return $query->where('estado_pago', $estado);
+    }
+
+    public function getDiferenciaPagoAttribute(): float
+    {
+        $total = (float) $this->monto_total;
+        $pagado = (float) $this->monto_pagado;
+
+        return round($total - $pagado, 2);
+    }
+
+    public function getEstaPagadoAttribute(): bool
+    {
+        return $this->diferencia_pago <= 0 && $this->estado_pago === self::ESTADO_PAGO_PAGADO;
     }
 }

--- a/app/Models/Producto.php
+++ b/app/Models/Producto.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Producto extends Model
 {
+    use HasFactory;
+
     protected $table = 'productos';
 
     public function categoria()

--- a/app/Models/Tienda.php
+++ b/app/Models/Tienda.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Tienda extends Model
 {
+    use HasFactory;
+
     protected $table = 'tiendas';
 
     public function vendedores()

--- a/app/Models/Vendedor.php
+++ b/app/Models/Vendedor.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Vendedor extends Model
 {
+    use HasFactory;
+
     protected $table = 'vendedores';
 
     public function tienda()

--- a/database/factories/AlmacenFactory.php
+++ b/database/factories/AlmacenFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Almacen;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Almacen>
+ */
+class AlmacenFactory extends Factory
+{
+    protected $model = Almacen::class;
+
+    public function definition(): array
+    {
+        return [
+            'nombre' => $this->faker->unique()->randomElement(['Curva', 'Milla', 'Santa Carolina', $this->faker->company()]),
+            'direccion' => $this->faker->address(),
+        ];
+    }
+}

--- a/database/factories/CategoriaFactory.php
+++ b/database/factories/CategoriaFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Categoria;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Categoria>
+ */
+class CategoriaFactory extends Factory
+{
+    protected $model = Categoria::class;
+
+    public function definition(): array
+    {
+        return [
+            'nombre' => $this->faker->unique()->randomElement([
+                'Materiales de construcción',
+                'Acabados',
+                'Herramientas',
+                'Ferretería',
+            ]),
+        ];
+    }
+}

--- a/database/factories/CobroFactory.php
+++ b/database/factories/CobroFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Cobro;
+use App\Models\Pedido;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Cobro>
+ */
+class CobroFactory extends Factory
+{
+    protected $model = Cobro::class;
+
+    public function definition(): array
+    {
+        $monto = $this->faker->randomFloat(2, 50, 500);
+        $montoPagado = $this->faker->randomFloat(2, 0, $monto);
+        $tipoPago = $montoPagado > 0 ? $this->faker->randomElement(Cobro::TIPOS_PAGO) : null;
+        $estadoPago = $montoPagado >= $monto
+            ? Cobro::ESTADO_PAGO_PAGADO
+            : ($montoPagado > 0 ? Cobro::ESTADO_PAGO_POR_COBRAR : Cobro::ESTADO_PAGO_PENDIENTE);
+
+        return [
+            'pedido_id' => Pedido::factory(),
+            'monto' => $monto,
+            'monto_pagado' => $montoPagado,
+            'tipo_pago' => $tipoPago,
+            'estado_pago' => $estadoPago,
+            'metodo' => $tipoPago ?? Cobro::TIPO_PAGO_EFECTIVO,
+            'registrado_por' => User::factory(),
+            'observaciones' => $this->faker->optional()->sentence(),
+        ];
+    }
+}

--- a/database/factories/DetallePedidoFactory.php
+++ b/database/factories/DetallePedidoFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DetallePedido;
+use App\Models\Pedido;
+use App\Models\Producto;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\DetallePedido>
+ */
+class DetallePedidoFactory extends Factory
+{
+    protected $model = DetallePedido::class;
+
+    public function definition(): array
+    {
+        $cantidad = $this->faker->randomFloat(2, 1, 100);
+        $precioUnitario = $this->faker->randomFloat(2, 5, 200);
+
+        return [
+            'pedido_id' => Pedido::factory(),
+            'producto_id' => Producto::factory(),
+            'cantidad' => $cantidad,
+            'unidad' => $this->faker->randomElement(DetallePedido::UNIDADES),
+            'metraje' => $this->faker->optional()->randomFloat(2, 1, 80),
+            'precio_unitario' => $precioUnitario,
+            'precio_final' => $precioUnitario,
+            'subtotal' => round($cantidad * $precioUnitario, 2),
+        ];
+    }
+}

--- a/database/factories/PedidoFactory.php
+++ b/database/factories/PedidoFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Almacen;
+use App\Models\DetallePedido;
+use App\Models\Pedido;
+use App\Models\Tienda;
+use App\Models\User;
+use App\Models\Vendedor;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Pedido>
+ */
+class PedidoFactory extends Factory
+{
+    protected $model = Pedido::class;
+
+    public function definition(): array
+    {
+        $montoTotal = $this->faker->randomFloat(2, 300, 2000);
+        $montoPagado = $this->faker->randomFloat(2, 0, $montoTotal);
+        $cantidadTotal = $this->faker->randomFloat(2, 5, 250);
+        $metrajeTotal = $this->faker->randomFloat(2, 10, 150);
+        $tipoPago = $montoPagado > 0 ? $this->faker->randomElement(Pedido::TIPOS_PAGO) : null;
+        $estadoPago = $montoPagado >= $montoTotal
+            ? Pedido::ESTADO_PAGO_PAGADO
+            : ($montoPagado > 0 ? Pedido::ESTADO_PAGO_POR_COBRAR : Pedido::ESTADO_PAGO_PENDIENTE);
+
+        return [
+            'tienda_id' => Tienda::factory(),
+            'vendedor_id' => Vendedor::factory(),
+            'almacen_id' => Almacen::factory(),
+            'almacen_destino_id' => Almacen::factory(),
+            'encargado_id' => User::factory(),
+            'monto_total' => $montoTotal,
+            'monto_pagado' => $montoPagado,
+            'saldo_pendiente' => max($montoTotal - $montoPagado, 0),
+            'metraje_total' => $metrajeTotal,
+            'cantidad_total' => $cantidadTotal,
+            'unidad_referencia' => $this->faker->randomElement(DetallePedido::UNIDADES),
+            'precio_promedio' => $cantidadTotal > 0 ? round($montoTotal / $cantidadTotal, 2) : $montoTotal,
+            'tipo_entrega' => $this->faker->randomElement(Pedido::TIPOS_ENTREGA),
+            'tipo_pago' => $tipoPago,
+            'estado_pago' => $estadoPago,
+            'estado_pedido' => $this->faker->randomElement(Pedido::ESTADOS_PEDIDO),
+            'cobra_almacen' => $this->faker->boolean(),
+            'notas' => $this->faker->optional()->sentence(),
+        ];
+    }
+}

--- a/database/factories/ProductoFactory.php
+++ b/database/factories/ProductoFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Categoria;
+use App\Models\DetallePedido;
+use App\Models\Producto;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Producto>
+ */
+class ProductoFactory extends Factory
+{
+    protected $model = Producto::class;
+
+    public function definition(): array
+    {
+        return [
+            'categoria_id' => Categoria::factory(),
+            'nombre' => $this->faker->unique()->randomElement([
+                'Bloque de concreto 20x40',
+                'Cemento Portland',
+                'Varilla corrugada 3/8',
+                'Pintura látex interior',
+            ]),
+            'medida' => $this->faker->randomElement(['25kg', '50kg', '1gl', 'unid']),
+            'unidad' => $this->faker->randomElement(DetallePedido::UNIDADES),
+            'piezas_por_caja' => $this->faker->numberBetween(1, 20),
+            'precio_referencial' => $this->faker->randomFloat(2, 10, 250),
+        ];
+    }
+}

--- a/database/factories/TiendaFactory.php
+++ b/database/factories/TiendaFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Tienda;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Tienda>
+ */
+class TiendaFactory extends Factory
+{
+    protected $model = Tienda::class;
+
+    public function definition(): array
+    {
+        return [
+            'nombre' => $this->faker->company(),
+            'sector' => $this->faker->randomElement(['Curva', 'Milla', 'Santa Carolina', 'Industrial', 'Residencial']),
+            'direccion' => $this->faker->address(),
+            'telefono' => $this->faker->phoneNumber(),
+        ];
+    }
+}

--- a/database/factories/VendedorFactory.php
+++ b/database/factories/VendedorFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Tienda;
+use App\Models\Vendedor;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Vendedor>
+ */
+class VendedorFactory extends Factory
+{
+    protected $model = Vendedor::class;
+
+    public function definition(): array
+    {
+        return [
+            'tienda_id' => Tienda::factory(),
+            'nombre' => $this->faker->name(),
+            'telefono' => $this->faker->phoneNumber(),
+        ];
+    }
+}

--- a/database/migrations/2025_10_10_000100_add_extended_fields_to_pedidos_table.php
+++ b/database/migrations/2025_10_10_000100_add_extended_fields_to_pedidos_table.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('pedidos', function (Blueprint $table) {
+            $table->foreignId('almacen_destino_id')
+                ->nullable()
+                ->after('almacen_id')
+                ->constrained('almacenes')
+                ->nullOnDelete();
+            $table->enum('tipo_entrega', ['recojo_almacen', 'envio_tienda', 'delivery_cliente'])
+                ->default('recojo_almacen')
+                ->after('almacen_destino_id');
+            $table->decimal('metraje_total', 10, 2)
+                ->nullable()
+                ->after('saldo_pendiente');
+            $table->decimal('cantidad_total', 10, 2)
+                ->nullable()
+                ->after('metraje_total');
+            $table->string('unidad_referencia', 25)
+                ->nullable()
+                ->after('cantidad_total');
+            $table->decimal('precio_promedio', 10, 2)
+                ->nullable()
+                ->after('unidad_referencia');
+            $table->decimal('monto_pagado', 10, 2)
+                ->default(0)
+                ->after('monto_total');
+            $table->enum('tipo_pago', ['efectivo', 'yape', 'plin', 'bcp', 'interbank', 'bbva'])
+                ->nullable()
+                ->after('monto_pagado');
+            $table->enum('estado_pago', ['pendiente', 'por_cobrar', 'vuelto', 'pagado'])
+                ->default('pendiente')
+                ->after('tipo_pago');
+            $table->enum('estado_pedido', ['pendiente', 'en_curso', 'entregado', 'anulado'])
+                ->default('pendiente')
+                ->after('estado_pago');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('pedidos', function (Blueprint $table) {
+            $table->dropColumn([
+                'tipo_entrega',
+                'metraje_total',
+                'cantidad_total',
+                'unidad_referencia',
+                'precio_promedio',
+                'monto_pagado',
+                'tipo_pago',
+                'estado_pago',
+                'estado_pedido',
+            ]);
+
+            $table->dropForeign(['almacen_destino_id']);
+            $table->dropColumn('almacen_destino_id');
+        });
+    }
+};

--- a/database/migrations/2025_10_10_000110_add_metrics_to_detalle_pedido_table.php
+++ b/database/migrations/2025_10_10_000110_add_metrics_to_detalle_pedido_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('detalle_pedido', function (Blueprint $table) {
+            $table->decimal('metraje', 10, 2)->nullable()->after('cantidad');
+            $table->decimal('precio_unitario', 10, 2)->nullable()->after('precio_final');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('detalle_pedido', function (Blueprint $table) {
+            $table->dropColumn(['metraje', 'precio_unitario']);
+        });
+    }
+};

--- a/database/migrations/2025_10_10_000120_add_payment_fields_to_cobros_table.php
+++ b/database/migrations/2025_10_10_000120_add_payment_fields_to_cobros_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('cobros', function (Blueprint $table) {
+            $table->decimal('monto_pagado', 10, 2)->default(0)->after('monto');
+            $table->enum('tipo_pago', ['efectivo', 'yape', 'plin', 'bcp', 'interbank', 'bbva'])
+                ->nullable()
+                ->after('monto_pagado');
+            $table->enum('estado_pago', ['pendiente', 'por_cobrar', 'vuelto', 'pagado'])
+                ->default('pendiente')
+                ->after('tipo_pago');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('cobros', function (Blueprint $table) {
+            $table->dropColumn(['monto_pagado', 'tipo_pago', 'estado_pago']);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,15 @@
 
 namespace Database\Seeders;
 
+use App\Models\Almacen;
+use App\Models\Categoria;
+use App\Models\Cobro;
+use App\Models\DetallePedido;
+use App\Models\Pedido;
+use App\Models\Producto;
+use App\Models\Tienda;
 use App\Models\User;
+use App\Models\Vendedor;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
 
@@ -31,5 +39,193 @@ class DatabaseSeeder extends Seeder
         if (!$user->hasRole('Supervisor')) {
             $user->assignRole('Supervisor');
         }
+
+        $almacenes = collect([
+            ['nombre' => 'Curva', 'direccion' => 'Av. La Curva 120 - Trujillo'],
+            ['nombre' => 'Milla', 'direccion' => 'Jr. Milla 450 - Trujillo'],
+            ['nombre' => 'Santa Carolina', 'direccion' => 'Av. Santa Carolina 900 - Trujillo'],
+        ])->mapWithKeys(fn (array $almacen) => [
+            $almacen['nombre'] => Almacen::updateOrCreate(
+                ['nombre' => $almacen['nombre']],
+                ['direccion' => $almacen['direccion']]
+            ),
+        ]);
+
+        $tienda = Tienda::updateOrCreate(
+            ['nombre' => 'Ferretería El Porvenir'],
+            [
+                'sector' => 'Curva',
+                'direccion' => 'Av. Las Magnolias 315 - El Porvenir',
+                'telefono' => '944-123-456',
+            ]
+        );
+
+        $vendedor = Vendedor::updateOrCreate(
+            [
+                'tienda_id' => $tienda->id,
+                'nombre' => 'María Torres',
+            ],
+            ['telefono' => '900-111-222']
+        );
+
+        $categoria = Categoria::firstOrCreate(['nombre' => 'Construcción']);
+
+        $productos = [
+            'ladrillo' => Producto::updateOrCreate(
+                ['nombre' => 'Ladrillo King Kong 18H'],
+                [
+                    'categoria_id' => $categoria->id,
+                    'medida' => 'caja 25 und',
+                    'unidad' => DetallePedido::UNIDAD_CAJA,
+                    'piezas_por_caja' => 25,
+                    'precio_referencial' => 13.50,
+                ]
+            ),
+            'cemento' => Producto::updateOrCreate(
+                ['nombre' => 'Cemento Portland Tipo I'],
+                [
+                    'categoria_id' => $categoria->id,
+                    'medida' => 'bolsa 42.5kg',
+                    'unidad' => DetallePedido::UNIDAD_KG,
+                    'piezas_por_caja' => 1,
+                    'precio_referencial' => 32.80,
+                ]
+            ),
+            'yeso' => Producto::updateOrCreate(
+                ['nombre' => 'Yeso en polvo 25kg'],
+                [
+                    'categoria_id' => $categoria->id,
+                    'medida' => 'saco 25kg',
+                    'unidad' => DetallePedido::UNIDAD_KG,
+                    'piezas_por_caja' => 1,
+                    'precio_referencial' => 18.90,
+                ]
+            ),
+        ];
+
+        $pedidoParcial = Pedido::updateOrCreate(
+            ['notas' => 'Pedido parcial con transferencia BCP'],
+            [
+                'tienda_id' => $tienda->id,
+                'vendedor_id' => $vendedor->id,
+                'almacen_id' => $almacenes['Curva']->id,
+                'almacen_destino_id' => $almacenes['Milla']->id,
+                'encargado_id' => $user->id,
+                'monto_total' => 1200.00,
+                'monto_pagado' => 700.00,
+                'saldo_pendiente' => 500.00,
+                'metraje_total' => 48.50,
+                'cantidad_total' => 80,
+                'unidad_referencia' => DetallePedido::UNIDAD_CAJA,
+                'precio_promedio' => 15.00,
+                'tipo_entrega' => Pedido::TIPO_ENTREGA_ENVIO_TIENDA,
+                'tipo_pago' => Pedido::TIPO_PAGO_BCP,
+                'estado_pago' => Pedido::ESTADO_PAGO_POR_COBRAR,
+                'estado_pedido' => Pedido::ESTADO_PEDIDO_EN_CURSO,
+                'cobra_almacen' => true,
+            ]
+        );
+
+        $pedidoParcial->detalles()->delete();
+        $pedidoParcial->cobros()->delete();
+
+        $pedidoParcial->detalles()->createMany([
+            [
+                'producto_id' => $productos['ladrillo']->id,
+                'cantidad' => 50,
+                'unidad' => DetallePedido::UNIDAD_CAJA,
+                'metraje' => 30.25,
+                'precio_unitario' => 12.00,
+                'precio_final' => 12.00,
+                'subtotal' => 600.00,
+            ],
+            [
+                'producto_id' => $productos['cemento']->id,
+                'cantidad' => 30,
+                'unidad' => DetallePedido::UNIDAD_KG,
+                'metraje' => 18.25,
+                'precio_unitario' => 20.00,
+                'precio_final' => 20.00,
+                'subtotal' => 600.00,
+            ],
+        ]);
+
+        $pedidoParcial->cobros()->createMany([
+            [
+                'monto' => 400.00,
+                'monto_pagado' => 400.00,
+                'tipo_pago' => Cobro::TIPO_PAGO_BCP,
+                'estado_pago' => Cobro::ESTADO_PAGO_PAGADO,
+                'metodo' => Cobro::TIPO_PAGO_BCP,
+                'registrado_por' => $user->id,
+                'observaciones' => 'Transferencia BCP inicial',
+            ],
+            [
+                'monto' => 300.00,
+                'monto_pagado' => 300.00,
+                'tipo_pago' => Cobro::TIPO_PAGO_YAPE,
+                'estado_pago' => Cobro::ESTADO_PAGO_PAGADO,
+                'metodo' => Cobro::TIPO_PAGO_YAPE,
+                'registrado_por' => $user->id,
+                'observaciones' => 'Pago adicional con Yape',
+            ],
+        ]);
+
+        $pedidoCompleto = Pedido::updateOrCreate(
+            ['notas' => 'Pedido entregado y cancelado en efectivo'],
+            [
+                'tienda_id' => $tienda->id,
+                'vendedor_id' => $vendedor->id,
+                'almacen_id' => $almacenes['Santa Carolina']->id,
+                'almacen_destino_id' => $almacenes['Curva']->id,
+                'encargado_id' => $user->id,
+                'monto_total' => 850.00,
+                'monto_pagado' => 850.00,
+                'saldo_pendiente' => 0.00,
+                'metraje_total' => 35.75,
+                'cantidad_total' => 60,
+                'unidad_referencia' => DetallePedido::UNIDAD_CAJA,
+                'precio_promedio' => 14.17,
+                'tipo_entrega' => Pedido::TIPO_ENTREGA_DELIVERY_CLIENTE,
+                'tipo_pago' => Pedido::TIPO_PAGO_EFECTIVO,
+                'estado_pago' => Pedido::ESTADO_PAGO_PAGADO,
+                'estado_pedido' => Pedido::ESTADO_PEDIDO_ENTREGADO,
+                'cobra_almacen' => false,
+            ]
+        );
+
+        $pedidoCompleto->detalles()->delete();
+        $pedidoCompleto->cobros()->delete();
+
+        $pedidoCompleto->detalles()->createMany([
+            [
+                'producto_id' => $productos['ladrillo']->id,
+                'cantidad' => 40,
+                'unidad' => DetallePedido::UNIDAD_CAJA,
+                'metraje' => 20.50,
+                'precio_unitario' => 13.50,
+                'precio_final' => 13.50,
+                'subtotal' => 540.00,
+            ],
+            [
+                'producto_id' => $productos['yeso']->id,
+                'cantidad' => 20,
+                'unidad' => DetallePedido::UNIDAD_KG,
+                'metraje' => 15.25,
+                'precio_unitario' => 15.50,
+                'precio_final' => 15.50,
+                'subtotal' => 310.00,
+            ],
+        ]);
+
+        $pedidoCompleto->cobros()->create([
+            'monto' => 850.00,
+            'monto_pagado' => 850.00,
+            'tipo_pago' => Cobro::TIPO_PAGO_EFECTIVO,
+            'estado_pago' => Cobro::ESTADO_PAGO_PAGADO,
+            'metodo' => Cobro::TIPO_PAGO_EFECTIVO,
+            'registrado_por' => $user->id,
+            'observaciones' => 'Cancelado en efectivo contra entrega',
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- add logistics and payment tracking columns to pedidos, detalle_pedido and cobros tables
- expose enums, fillable attributes, casts and scopes on Pedido, DetallePedido and Cobro for status/difference calculations
- create factories and seed demo warehouses with partial and full payment scenarios

## Testing
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8f42e164832188b244ff802aa75f