### PR TITLE
Implementa módulos CRUD y flujo de pedidos con permisos

### DIFF
--- a/app/Http/Controllers/Admin/PermissionsController.php
+++ b/app/Http/Controllers/Admin/PermissionsController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Illuminate\View\View;
+use Spatie\Permission\Models\Role;
+
+class PermissionsController extends Controller
+{
+    public function index(): View
+    {
+        $roles = Role::with('permissions')->orderBy('name')->get();
+        $modules = config('modules.menus');
+
+        return view('admin.permissions.index', compact('roles', 'modules'));
+    }
+
+    public function update(Request $request): RedirectResponse
+    {
+        $modules = collect(config('modules.menus'));
+        $modulePermissions = $modules->pluck('permission')->filter()->values();
+
+        $validated = $request->validate([
+            'roles' => ['nullable', 'array'],
+            'roles.*' => ['array'],
+            'roles.*.*' => ['string', Rule::in($modulePermissions->toArray())],
+        ]);
+
+        $rolesData = $validated['roles'] ?? [];
+
+        foreach (Role::with('permissions')->get() as $role) {
+            $selectedPermissions = array_values(array_unique($rolesData[$role->id] ?? []));
+            $currentPermissions = $role->permissions->pluck('name')->toArray();
+
+            $nonModulePermissions = array_diff($currentPermissions, $modulePermissions->toArray());
+            $role->syncPermissions(array_merge($nonModulePermissions, $selectedPermissions));
+        }
+
+        return redirect()->route('admin.permissions.index')->with('status', 'Permisos de visualización actualizados.');
+    }
+}

--- a/app/Http/Controllers/AlmacenPedidoController.php
+++ b/app/Http/Controllers/AlmacenPedidoController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Pedido;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class AlmacenPedidoController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $almacenId = $request->user()?->almacen_id;
+
+        abort_if(empty($almacenId), 403, 'El usuario no tiene un almacén asignado.');
+
+        $pedidos = Pedido::with(['tienda', 'vendedor', 'almacen', 'almacenDestino', 'encargado'])
+            ->where('almacen_destino_id', $almacenId)
+            ->latest()
+            ->paginate(20);
+
+        return view('almacen.pedidos.index', compact('pedidos'));
+    }
+
+    public function show(Request $request, Pedido $pedido): View
+    {
+        $almacenId = $request->user()?->almacen_id;
+
+        abort_if(empty($almacenId), 403, 'El usuario no tiene un almacén asignado.');
+        abort_if((int) $pedido->almacen_destino_id !== (int) $almacenId, 403);
+
+        $pedido->load(['tienda', 'vendedor', 'almacen', 'almacenDestino', 'encargado', 'detalles.producto']);
+        $cambio = max((float) $pedido->monto_pagado - (float) $pedido->monto_total, 0);
+
+        return view('almacen.pedidos.show', compact('pedido', 'cambio'));
+    }
+}

--- a/app/Http/Controllers/CategoriaController.php
+++ b/app/Http/Controllers/CategoriaController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Categoria\StoreCategoriaRequest;
+use App\Http\Requests\Categoria\UpdateCategoriaRequest;
+use App\Models\Categoria;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class CategoriaController extends Controller
+{
+    public function index(): View
+    {
+        $categorias = Categoria::orderBy('nombre')->paginate(15);
+
+        return view('categorias.index', compact('categorias'));
+    }
+
+    public function create(): View
+    {
+        return view('categorias.create');
+    }
+
+    public function store(StoreCategoriaRequest $request): RedirectResponse
+    {
+        Categoria::create($request->validated());
+
+        return redirect()->route('categorias.index')->with('status', 'Categoría creada correctamente.');
+    }
+
+    public function show(Categoria $categoria): View
+    {
+        return view('categorias.show', compact('categoria'));
+    }
+
+    public function edit(Categoria $categoria): View
+    {
+        return view('categorias.edit', compact('categoria'));
+    }
+
+    public function update(UpdateCategoriaRequest $request, Categoria $categoria): RedirectResponse
+    {
+        $categoria->update($request->validated());
+
+        return redirect()->route('categorias.index')->with('status', 'Categoría actualizada correctamente.');
+    }
+
+    public function destroy(Categoria $categoria): RedirectResponse
+    {
+        $categoria->delete();
+
+        return redirect()->route('categorias.index')->with('status', 'Categoría eliminada correctamente.');
+    }
+}

--- a/app/Http/Controllers/CierreAlmacenController.php
+++ b/app/Http/Controllers/CierreAlmacenController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Almacen;
+use App\Models\Pedido;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class CierreAlmacenController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $fecha = $request->input('fecha');
+        $almacenId = $request->input('almacen_id');
+
+        $cierres = Pedido::query()
+            ->selectRaw('DATE(pedidos.created_at) as fecha')
+            ->selectRaw('pedidos.almacen_destino_id')
+            ->selectRaw('SUM(pedidos.monto_total) as total_monto')
+            ->selectRaw('SUM(pedidos.monto_pagado) as total_pagado')
+            ->selectRaw('SUM(pedidos.saldo_pendiente) as total_pendiente')
+            ->selectRaw('SUM(CASE WHEN pedidos.monto_pagado > pedidos.monto_total THEN pedidos.monto_pagado - pedidos.monto_total ELSE 0 END) as total_vuelto')
+            ->leftJoin('almacenes', 'almacenes.id', '=', 'pedidos.almacen_destino_id')
+            ->addSelect('almacenes.nombre as almacen_nombre')
+            ->when($fecha, fn ($query) => $query->whereDate('pedidos.created_at', Carbon::parse($fecha)))
+            ->when($almacenId, fn ($query) => $query->where('pedidos.almacen_destino_id', $almacenId))
+            ->groupBy('fecha', 'pedidos.almacen_destino_id', 'almacenes.nombre')
+            ->orderByDesc('fecha')
+            ->orderBy('almacenes.nombre')
+            ->paginate(15);
+
+        $almacenes = Almacen::orderBy('nombre')->pluck('nombre', 'id');
+
+        return view('cierres.index', compact('cierres', 'fecha', 'almacenId', 'almacenes'));
+    }
+}

--- a/app/Http/Controllers/PedidoController.php
+++ b/app/Http/Controllers/PedidoController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Pedido\StorePedidoRequest;
+use App\Http\Requests\Pedido\UpdatePedidoRequest;
+use App\Models\Almacen;
+use App\Models\Pedido;
+use App\Models\Tienda;
+use App\Models\User;
+use App\Models\Vendedor;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class PedidoController extends Controller
+{
+    public function index(): View
+    {
+        $pedidos = Pedido::with(['tienda', 'vendedor', 'almacen', 'almacenDestino', 'encargado'])
+            ->latest()
+            ->paginate(20);
+
+        return view('pedidos.index', compact('pedidos'));
+    }
+
+    public function create(): View
+    {
+        return view('pedidos.create', $this->formData());
+    }
+
+    public function store(StorePedidoRequest $request): RedirectResponse
+    {
+        $data = $request->validated();
+        $cambio = $request->cambioCalculado();
+
+        $pedido = Pedido::create($data);
+
+        return redirect()
+            ->route('supervisor.pedidos.show', $pedido)
+            ->with('status', $this->mensajeExitoso('Pedido registrado correctamente.', $cambio));
+    }
+
+    public function show(Pedido $pedido): View
+    {
+        $pedido->load(['tienda', 'vendedor', 'almacen', 'almacenDestino', 'encargado', 'detalles.producto']);
+        $cambio = max((float) $pedido->monto_pagado - (float) $pedido->monto_total, 0);
+
+        return view('pedidos.show', compact('pedido', 'cambio'));
+    }
+
+    public function edit(Pedido $pedido): View
+    {
+        $pedido->load(['tienda', 'vendedor', 'almacen', 'almacenDestino', 'encargado']);
+
+        return view('pedidos.edit', array_merge(['pedido' => $pedido], $this->formData()));
+    }
+
+    public function update(UpdatePedidoRequest $request, Pedido $pedido): RedirectResponse
+    {
+        $data = $request->validated();
+        $cambio = $request->cambioCalculado();
+
+        $pedido->update($data);
+
+        return redirect()
+            ->route('supervisor.pedidos.show', $pedido)
+            ->with('status', $this->mensajeExitoso('Pedido actualizado correctamente.', $cambio));
+    }
+
+    public function destroy(Pedido $pedido): RedirectResponse
+    {
+        $pedido->delete();
+
+        return redirect()->route('supervisor.pedidos.index')->with('status', 'Pedido eliminado correctamente.');
+    }
+
+    protected function formData(): array
+    {
+        $tiendas = Tienda::orderBy('nombre')->pluck('nombre', 'id');
+        $vendedores = Vendedor::orderBy('nombre')->pluck('nombre', 'id');
+        $almacenes = Almacen::orderBy('nombre')->pluck('nombre', 'id');
+        $encargados = User::role('Encargado')->orderBy('name')->pluck('name', 'id');
+
+        return [
+            'tiendas' => $tiendas,
+            'vendedores' => $vendedores,
+            'almacenes' => $almacenes,
+            'encargados' => $encargados,
+            'tiposEntrega' => Pedido::TIPOS_ENTREGA,
+            'tiposPago' => Pedido::TIPOS_PAGO,
+            'estadosPedido' => Pedido::ESTADOS_PEDIDO,
+        ];
+    }
+
+    protected function mensajeExitoso(string $mensajeBase, float $cambio): string
+    {
+        if ($cambio > 0) {
+            return sprintf('%s Se registró un vuelto de S/ %s.', $mensajeBase, number_format($cambio, 2));
+        }
+
+        return $mensajeBase;
+    }
+}

--- a/app/Http/Controllers/ProductoController.php
+++ b/app/Http/Controllers/ProductoController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Producto\StoreProductoRequest;
+use App\Http\Requests\Producto\UpdateProductoRequest;
+use App\Models\Categoria;
+use App\Models\Producto;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class ProductoController extends Controller
+{
+    public function index(): View
+    {
+        $productos = Producto::with('categoria')->orderBy('nombre')->paginate(15);
+
+        return view('productos.index', compact('productos'));
+    }
+
+    public function create(): View
+    {
+        $categorias = Categoria::orderBy('nombre')->pluck('nombre', 'id');
+
+        return view('productos.create', [
+            'categorias' => $categorias,
+            'unidades' => Producto::UNIDADES,
+        ]);
+    }
+
+    public function store(StoreProductoRequest $request): RedirectResponse
+    {
+        Producto::create($request->validated());
+
+        return redirect()->route('productos.index')->with('status', 'Producto registrado correctamente.');
+    }
+
+    public function show(Producto $producto): View
+    {
+        $producto->load('categoria');
+
+        return view('productos.show', compact('producto'));
+    }
+
+    public function edit(Producto $producto): View
+    {
+        $categorias = Categoria::orderBy('nombre')->pluck('nombre', 'id');
+
+        return view('productos.edit', [
+            'producto' => $producto,
+            'categorias' => $categorias,
+            'unidades' => Producto::UNIDADES,
+        ]);
+    }
+
+    public function update(UpdateProductoRequest $request, Producto $producto): RedirectResponse
+    {
+        $producto->update($request->validated());
+
+        return redirect()->route('productos.index')->with('status', 'Producto actualizado correctamente.');
+    }
+
+    public function destroy(Producto $producto): RedirectResponse
+    {
+        $producto->delete();
+
+        return redirect()->route('productos.index')->with('status', 'Producto eliminado correctamente.');
+    }
+}

--- a/app/Http/Controllers/TiendaController.php
+++ b/app/Http/Controllers/TiendaController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Tienda\StoreTiendaRequest;
+use App\Http\Requests\Tienda\UpdateTiendaRequest;
+use App\Models\Tienda;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class TiendaController extends Controller
+{
+    public function index(): View
+    {
+        $tiendas = Tienda::orderBy('nombre')->paginate(15);
+
+        return view('tiendas.index', compact('tiendas'));
+    }
+
+    public function create(): View
+    {
+        return view('tiendas.create');
+    }
+
+    public function store(StoreTiendaRequest $request): RedirectResponse
+    {
+        Tienda::create($request->validated());
+
+        return redirect()->route('tiendas.index')->with('status', 'Tienda registrada correctamente.');
+    }
+
+    public function show(Tienda $tienda): View
+    {
+        $tienda->load('vendedores');
+
+        return view('tiendas.show', compact('tienda'));
+    }
+
+    public function edit(Tienda $tienda): View
+    {
+        return view('tiendas.edit', compact('tienda'));
+    }
+
+    public function update(UpdateTiendaRequest $request, Tienda $tienda): RedirectResponse
+    {
+        $tienda->update($request->validated());
+
+        return redirect()->route('tiendas.index')->with('status', 'Tienda actualizada correctamente.');
+    }
+
+    public function destroy(Tienda $tienda): RedirectResponse
+    {
+        $tienda->delete();
+
+        return redirect()->route('tiendas.index')->with('status', 'Tienda eliminada correctamente.');
+    }
+}

--- a/app/Http/Controllers/VendedorController.php
+++ b/app/Http/Controllers/VendedorController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Vendedor\StoreVendedorRequest;
+use App\Http\Requests\Vendedor\UpdateVendedorRequest;
+use App\Models\Tienda;
+use App\Models\Vendedor;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class VendedorController extends Controller
+{
+    public function index(): View
+    {
+        $vendedores = Vendedor::with('tienda')->orderBy('nombre')->paginate(15);
+
+        return view('vendedores.index', compact('vendedores'));
+    }
+
+    public function create(): View
+    {
+        $tiendas = Tienda::orderBy('nombre')->pluck('nombre', 'id');
+
+        return view('vendedores.create', compact('tiendas'));
+    }
+
+    public function store(StoreVendedorRequest $request): RedirectResponse
+    {
+        Vendedor::create($request->validated());
+
+        return redirect()->route('vendedores.index')->with('status', 'Vendedor registrado correctamente.');
+    }
+
+    public function show(Vendedor $vendedor): View
+    {
+        $vendedor->load('tienda');
+
+        return view('vendedores.show', compact('vendedor'));
+    }
+
+    public function edit(Vendedor $vendedor): View
+    {
+        $tiendas = Tienda::orderBy('nombre')->pluck('nombre', 'id');
+
+        return view('vendedores.edit', compact('vendedor', 'tiendas'));
+    }
+
+    public function update(UpdateVendedorRequest $request, Vendedor $vendedor): RedirectResponse
+    {
+        $vendedor->update($request->validated());
+
+        return redirect()->route('vendedores.index')->with('status', 'Vendedor actualizado correctamente.');
+    }
+
+    public function destroy(Vendedor $vendedor): RedirectResponse
+    {
+        $vendedor->delete();
+
+        return redirect()->route('vendedores.index')->with('status', 'Vendedor eliminado correctamente.');
+    }
+}

--- a/app/Http/Requests/Categoria/StoreCategoriaRequest.php
+++ b/app/Http/Requests/Categoria/StoreCategoriaRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Categoria;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCategoriaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('manage categorias') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'nombre' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/Categoria/UpdateCategoriaRequest.php
+++ b/app/Http/Requests/Categoria/UpdateCategoriaRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Categoria;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCategoriaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('manage categorias') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'nombre' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/Pedido/StorePedidoRequest.php
+++ b/app/Http/Requests/Pedido/StorePedidoRequest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Requests\Pedido;
+
+use App\Models\Pedido;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StorePedidoRequest extends FormRequest
+{
+    protected float $cambioCalculado = 0.0;
+
+    public function authorize(): bool
+    {
+        return $this->user()?->can('manage pedidos') ?? false;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'monto_pagado' => $this->input('monto_pagado', 0),
+            'cobra_almacen' => $this->boolean('cobra_almacen'),
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'tienda_id' => ['required', 'exists:tiendas,id'],
+            'vendedor_id' => ['required', 'exists:vendedores,id'],
+            'almacen_id' => ['required', 'exists:almacenes,id'],
+            'almacen_destino_id' => ['nullable', 'exists:almacenes,id'],
+            'encargado_id' => ['required', 'exists:users,id'],
+            'monto_total' => ['required', 'numeric', 'min:0'],
+            'monto_pagado' => ['nullable', 'numeric', 'min:0'],
+            'metraje_total' => ['nullable', 'numeric', 'min:0'],
+            'cantidad_total' => ['nullable', 'numeric', 'min:0'],
+            'unidad_referencia' => ['nullable', 'string', 'max:25'],
+            'precio_promedio' => ['nullable', 'numeric', 'min:0'],
+            'tipo_entrega' => ['required', 'string', Rule::in(Pedido::TIPOS_ENTREGA)],
+            'tipo_pago' => ['nullable', 'string', Rule::in(Pedido::TIPOS_PAGO)],
+            'estado_pedido' => ['required', 'string', Rule::in(Pedido::ESTADOS_PEDIDO)],
+            'notas' => ['nullable', 'string'],
+            'cobra_almacen' => ['required', 'boolean'],
+        ];
+    }
+
+    public function validated($key = null, $default = null)
+    {
+        $data = parent::validated($key, $default);
+
+        $montoTotal = (float) $data['monto_total'];
+        $montoPagado = (float) ($data['monto_pagado'] ?? 0);
+        $saldo = max($montoTotal - $montoPagado, 0);
+        $vuelto = max($montoPagado - $montoTotal, 0);
+
+        $data['monto_pagado'] = $montoPagado;
+        $data['saldo_pendiente'] = $saldo;
+        $data['estado_pago'] = $this->resolverEstadoPago($saldo, $montoPagado, $vuelto);
+
+        $this->cambioCalculado = $vuelto;
+
+        $data['cobra_almacen'] = (bool) ($data['cobra_almacen'] ?? false);
+
+        return $data;
+    }
+
+    public function cambioCalculado(): float
+    {
+        return $this->cambioCalculado;
+    }
+
+    protected function resolverEstadoPago(float $saldo, float $montoPagado, float $vuelto): string
+    {
+        if ($vuelto > 0) {
+            return Pedido::ESTADO_PAGO_VUELTO;
+        }
+
+        if ($saldo <= 0) {
+            return Pedido::ESTADO_PAGO_PAGADO;
+        }
+
+        return $montoPagado > 0 ? Pedido::ESTADO_PAGO_POR_COBRAR : Pedido::ESTADO_PAGO_PENDIENTE;
+    }
+}

--- a/app/Http/Requests/Pedido/UpdatePedidoRequest.php
+++ b/app/Http/Requests/Pedido/UpdatePedidoRequest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Requests\Pedido;
+
+use App\Models\Pedido;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdatePedidoRequest extends FormRequest
+{
+    protected float $cambioCalculado = 0.0;
+
+    public function authorize(): bool
+    {
+        return $this->user()?->can('manage pedidos') ?? false;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'monto_pagado' => $this->input('monto_pagado', 0),
+            'cobra_almacen' => $this->boolean('cobra_almacen'),
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'tienda_id' => ['required', 'exists:tiendas,id'],
+            'vendedor_id' => ['required', 'exists:vendedores,id'],
+            'almacen_id' => ['required', 'exists:almacenes,id'],
+            'almacen_destino_id' => ['nullable', 'exists:almacenes,id'],
+            'encargado_id' => ['required', 'exists:users,id'],
+            'monto_total' => ['required', 'numeric', 'min:0'],
+            'monto_pagado' => ['nullable', 'numeric', 'min:0'],
+            'metraje_total' => ['nullable', 'numeric', 'min:0'],
+            'cantidad_total' => ['nullable', 'numeric', 'min:0'],
+            'unidad_referencia' => ['nullable', 'string', 'max:25'],
+            'precio_promedio' => ['nullable', 'numeric', 'min:0'],
+            'tipo_entrega' => ['required', 'string', Rule::in(Pedido::TIPOS_ENTREGA)],
+            'tipo_pago' => ['nullable', 'string', Rule::in(Pedido::TIPOS_PAGO)],
+            'estado_pedido' => ['required', 'string', Rule::in(Pedido::ESTADOS_PEDIDO)],
+            'notas' => ['nullable', 'string'],
+            'cobra_almacen' => ['required', 'boolean'],
+        ];
+    }
+
+    public function validated($key = null, $default = null)
+    {
+        $data = parent::validated($key, $default);
+
+        $montoTotal = (float) $data['monto_total'];
+        $montoPagado = (float) ($data['monto_pagado'] ?? 0);
+        $saldo = max($montoTotal - $montoPagado, 0);
+        $vuelto = max($montoPagado - $montoTotal, 0);
+
+        $data['monto_pagado'] = $montoPagado;
+        $data['saldo_pendiente'] = $saldo;
+        $data['estado_pago'] = $this->resolverEstadoPago($saldo, $montoPagado, $vuelto);
+
+        $this->cambioCalculado = $vuelto;
+        $data['cobra_almacen'] = (bool) ($data['cobra_almacen'] ?? false);
+
+        return $data;
+    }
+
+    public function cambioCalculado(): float
+    {
+        return $this->cambioCalculado;
+    }
+
+    protected function resolverEstadoPago(float $saldo, float $montoPagado, float $vuelto): string
+    {
+        if ($vuelto > 0) {
+            return Pedido::ESTADO_PAGO_VUELTO;
+        }
+
+        if ($saldo <= 0) {
+            return Pedido::ESTADO_PAGO_PAGADO;
+        }
+
+        return $montoPagado > 0 ? Pedido::ESTADO_PAGO_POR_COBRAR : Pedido::ESTADO_PAGO_PENDIENTE;
+    }
+}

--- a/app/Http/Requests/Producto/StoreProductoRequest.php
+++ b/app/Http/Requests/Producto/StoreProductoRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Producto;
+
+use App\Models\Producto;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreProductoRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('manage productos') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'categoria_id' => ['required', 'exists:categorias,id'],
+            'nombre' => ['required', 'string', 'max:255'],
+            'medida' => ['nullable', 'string', 'max:255'],
+            'unidad' => ['required', 'string', Rule::in(Producto::UNIDADES)],
+            'piezas_por_caja' => ['required', 'integer', 'min:1'],
+            'precio_referencial' => ['required', 'numeric', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Requests/Producto/UpdateProductoRequest.php
+++ b/app/Http/Requests/Producto/UpdateProductoRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Producto;
+
+use App\Models\Producto;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateProductoRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('manage productos') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'categoria_id' => ['required', 'exists:categorias,id'],
+            'nombre' => ['required', 'string', 'max:255'],
+            'medida' => ['nullable', 'string', 'max:255'],
+            'unidad' => ['required', 'string', Rule::in(Producto::UNIDADES)],
+            'piezas_por_caja' => ['required', 'integer', 'min:1'],
+            'precio_referencial' => ['required', 'numeric', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Requests/Tienda/StoreTiendaRequest.php
+++ b/app/Http/Requests/Tienda/StoreTiendaRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Tienda;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTiendaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('manage tiendas') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'nombre' => ['required', 'string', 'max:255'],
+            'sector' => ['required', 'string', 'max:255'],
+            'direccion' => ['required', 'string', 'max:255'],
+            'telefono' => ['required', 'string', 'max:50'],
+        ];
+    }
+}

--- a/app/Http/Requests/Tienda/UpdateTiendaRequest.php
+++ b/app/Http/Requests/Tienda/UpdateTiendaRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Tienda;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTiendaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('manage tiendas') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'nombre' => ['required', 'string', 'max:255'],
+            'sector' => ['required', 'string', 'max:255'],
+            'direccion' => ['required', 'string', 'max:255'],
+            'telefono' => ['required', 'string', 'max:50'],
+        ];
+    }
+}

--- a/app/Http/Requests/Vendedor/StoreVendedorRequest.php
+++ b/app/Http/Requests/Vendedor/StoreVendedorRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Vendedor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreVendedorRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('manage vendedores') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'tienda_id' => ['required', 'exists:tiendas,id'],
+            'nombre' => ['required', 'string', 'max:255'],
+            'telefono' => ['required', 'string', 'max:50'],
+        ];
+    }
+}

--- a/app/Http/Requests/Vendedor/UpdateVendedorRequest.php
+++ b/app/Http/Requests/Vendedor/UpdateVendedorRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Vendedor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateVendedorRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('manage vendedores') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'tienda_id' => ['required', 'exists:tiendas,id'],
+            'nombre' => ['required', 'string', 'max:255'],
+            'telefono' => ['required', 'string', 'max:50'],
+        ];
+    }
+}

--- a/app/Models/Categoria.php
+++ b/app/Models/Categoria.php
@@ -10,6 +10,7 @@ class Categoria extends Model
     use HasFactory;
 
     protected $table = 'categorias';
+    protected $fillable = ['nombre'];
 
     public function productos()
     {

--- a/app/Models/Producto.php
+++ b/app/Models/Producto.php
@@ -10,6 +10,14 @@ class Producto extends Model
     use HasFactory;
 
     protected $table = 'productos';
+    protected $fillable = [
+        'categoria_id',
+        'nombre',
+        'medida',
+        'unidad',
+        'piezas_por_caja',
+        'precio_referencial',
+    ];
 
     public function categoria()
     {

--- a/app/Models/Tienda.php
+++ b/app/Models/Tienda.php
@@ -10,6 +10,7 @@ class Tienda extends Model
     use HasFactory;
 
     protected $table = 'tiendas';
+    protected $fillable = ['nombre', 'sector', 'direccion', 'telefono'];
 
     public function vendedores()
     {

--- a/app/Models/Vendedor.php
+++ b/app/Models/Vendedor.php
@@ -10,6 +10,7 @@ class Vendedor extends Model
     use HasFactory;
 
     protected $table = 'vendedores';
+    protected $fillable = ['tienda_id', 'nombre', 'telefono'];
 
     public function tienda()
     {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,8 +12,8 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->alias([
-            'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
-            'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
+            'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
+            'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/config/modules.php
+++ b/config/modules.php
@@ -2,13 +2,50 @@
 
 return [
     'menus' => [
-        'dashboard' => 'Dashboard',
-        'almacenes' => 'Almacenes',
-        'tiendas' => 'Tiendas',
-        'vendedores' => 'Vendedores',
-        'categorias' => 'Categorías',
-        'productos' => 'Productos',
-        'pedidos' => 'Pedidos',
-        'cobros' => 'Cobros',
+        'dashboard' => [
+            'label' => 'Dashboard',
+            'route' => 'dashboard',
+            'permission' => 'view dashboard',
+        ],
+        'tiendas' => [
+            'label' => 'Tiendas',
+            'route' => 'tiendas.index',
+            'permission' => 'view tiendas',
+        ],
+        'vendedores' => [
+            'label' => 'Vendedores',
+            'route' => 'vendedores.index',
+            'permission' => 'view vendedores',
+        ],
+        'categorias' => [
+            'label' => 'Categorías',
+            'route' => 'categorias.index',
+            'permission' => 'view categorias',
+        ],
+        'productos' => [
+            'label' => 'Productos',
+            'route' => 'productos.index',
+            'permission' => 'view productos',
+        ],
+        'pedidos' => [
+            'label' => 'Pedidos',
+            'route' => 'supervisor.pedidos.index',
+            'permission' => 'view pedidos',
+        ],
+        'almacen_pedidos' => [
+            'label' => 'Pedidos de Almacén',
+            'route' => 'almacen.pedidos.index',
+            'permission' => 'view pedidos almacenes',
+        ],
+        'cierres' => [
+            'label' => 'Cierre Diario',
+            'route' => 'supervisor.cierres.index',
+            'permission' => 'view cierres',
+        ],
+        'admin_permisos' => [
+            'label' => 'Permisos',
+            'route' => 'admin.permissions.index',
+            'permission' => 'view admin permisos',
+        ],
     ],
 ];

--- a/database/migrations/2025_10_10_000100_add_extended_fields_to_pedidos_table.php
+++ b/database/migrations/2025_10_10_000100_add_extended_fields_to_pedidos_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\\Database\\Migrations\\Migration;
-use Illuminate\\Database\\Schema\\Blueprint;
-use Illuminate\\Support\\Facades\\Schema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/database/migrations/2025_10_10_000110_add_metrics_to_detalle_pedido_table.php
+++ b/database/migrations/2025_10_10_000110_add_metrics_to_detalle_pedido_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\\Database\\Migrations\\Migration;
-use Illuminate\\Database\\Schema\\Blueprint;
-use Illuminate\\Support\\Facades\\Schema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/database/migrations/2025_10_10_000120_add_payment_fields_to_cobros_table.php
+++ b/database/migrations/2025_10_10_000120_add_payment_fields_to_cobros_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\\Database\\Migrations\\Migration;
-use Illuminate\\Database\\Schema\\Blueprint;
-use Illuminate\\Support\\Facades\\Schema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:2svYpN92yZc3OTBr5J0bLHk04WpxOwP1c3XqssigOks="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/resources/views/admin/permissions/index.blade.php
+++ b/resources/views/admin/permissions/index.blade.php
@@ -1,0 +1,52 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Permisos de módulos por rol') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                @if (session('status'))
+                    <div class="mb-4 rounded-md bg-green-50 p-4 text-sm text-green-700">{{ session('status') }}</div>
+                @endif
+
+                <form method="POST" action="{{ route('admin.permissions.update') }}" class="space-y-8">
+                    @csrf
+                    @method('PUT')
+
+                    @foreach ($roles as $role)
+                        <div class="border border-gray-200 rounded-lg p-4">
+                            <h3 class="text-lg font-semibold text-gray-800 mb-4">{{ $role->name }}</h3>
+                            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                                @foreach ($modules as $moduleKey => $module)
+                                    @php
+                                        $permissionName = $module['permission'];
+                                    @endphp
+                                    <label class="flex items-start space-x-2">
+                                    <input
+                                        type="checkbox"
+                                        name="roles[{{ $role->id }}][]"
+                                        value="{{ $permissionName }}"
+                                        class="mt-1 rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
+                                        {{ $role->permissions->contains('name', $permissionName) ? 'checked' : '' }}
+                                    >
+                                        <span>
+                                            <span class="block font-medium text-gray-700">{{ $module['label'] }}</span>
+                                            <span class="block text-xs text-gray-500">{{ $module['route'] }}</span>
+                                        </span>
+                                    </label>
+                                @endforeach
+                            </div>
+                        </div>
+                    @endforeach
+
+                    <div class="flex justify-end">
+                        <x-primary-button>{{ __('Guardar cambios') }}</x-primary-button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/roles/index.blade.php
+++ b/resources/views/admin/roles/index.blade.php
@@ -21,19 +21,22 @@
                             <div>
                                 <h3 class="text-lg font-semibold text-gray-700 mb-4">{{ $role->name }}</h3>
                                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                                    @foreach ($modules as $moduleKey => $moduleLabel)
+                                    @foreach ($modules as $moduleKey => $module)
                                         @php
-                                            $permissionName = 'view ' . $moduleKey;
+                                            $permissionName = $module['permission'];
                                         @endphp
                                         <label class="flex items-start space-x-2">
                                             <input
                                                 type="checkbox"
                                                 name="roles[{{ $role->id }}][]"
                                                 value="{{ $permissionName }}"
-                                                class="mt-1"
+                                                class="mt-1 rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
                                                 {{ $role->permissions->contains('name', $permissionName) ? 'checked' : '' }}
                                             >
-                                            <span>{{ $moduleLabel }}</span>
+                                            <span>
+                                                <span class="block font-medium text-gray-700">{{ $module['label'] }}</span>
+                                                <span class="block text-xs text-gray-500">{{ $module['route'] }}</span>
+                                            </span>
                                         </label>
                                     @endforeach
                                 </div>

--- a/resources/views/admin/users/permissions.blade.php
+++ b/resources/views/admin/users/permissions.blade.php
@@ -17,19 +17,22 @@
                     </p>
 
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        @foreach ($modules as $moduleKey => $moduleLabel)
+                        @foreach ($modules as $moduleKey => $module)
                             @php
-                                $permissionName = 'view ' . $moduleKey;
+                                $permissionName = $module['permission'];
                             @endphp
                             <label class="flex items-start space-x-2">
                                 <input
                                     type="checkbox"
                                     name="permissions[]"
                                     value="{{ $permissionName }}"
-                                    class="mt-1"
+                                    class="mt-1 rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
                                     {{ in_array($permissionName, $userPermissions, true) ? 'checked' : '' }}
                                 >
-                                <span>{{ $moduleLabel }}</span>
+                                <span>
+                                    <span class="block font-medium text-gray-700">{{ $module['label'] }}</span>
+                                    <span class="block text-xs text-gray-500">{{ $module['route'] }}</span>
+                                </span>
                             </label>
                         @endforeach
                     </div>

--- a/resources/views/almacen/pedidos/index.blade.php
+++ b/resources/views/almacen/pedidos/index.blade.php
@@ -1,0 +1,54 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Pedidos asignados a mi almacén') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-4">
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Código') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Tienda') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Monto total') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Estado pedido') }}</th>
+                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Acciones') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($pedidos as $pedido)
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">#{{ $pedido->id }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $pedido->tienda?->nombre }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">S/ {{ number_format($pedido->monto_total, 2) }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold {{ $pedido->estado_pedido === \App\Models\Pedido::ESTADO_PEDIDO_ENTREGADO ? 'bg-green-100 text-green-800' : ($pedido->estado_pedido === \App\Models\Pedido::ESTADO_PEDIDO_ANULADO ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-800') }}">
+                                                {{ ucwords(str_replace('_', ' ', $pedido->estado_pedido)) }}
+                                            </span>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                            <a href="{{ route('almacen.pedidos.show', $pedido) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Ver detalle') }}</a>
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No hay pedidos asignados a este almacén.') }}</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div>
+                        {{ $pedidos->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/almacen/pedidos/show.blade.php
+++ b/resources/views/almacen/pedidos/show.blade.php
@@ -1,0 +1,93 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Detalle del pedido #:id', ['id' => $pedido->id]) }}
+            </h2>
+            <a href="{{ route('almacen.pedidos.index') }}" class="text-sm text-indigo-600 hover:text-indigo-800">
+                {{ __('Volver') }}
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-5xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-4">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Tienda') }}</h3>
+                            <p class="mt-1 text-lg text-gray-900">{{ $pedido->tienda?->nombre }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Vendedor') }}</h3>
+                            <p class="mt-1 text-lg text-gray-900">{{ $pedido->vendedor?->nombre }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Estado del pedido') }}</h3>
+                            <span class="inline-flex mt-1 items-center px-2 py-1 rounded-full text-xs font-semibold {{ $pedido->estado_pedido === \App\Models\Pedido::ESTADO_PEDIDO_ENTREGADO ? 'bg-green-100 text-green-800' : ($pedido->estado_pedido === \App\Models\Pedido::ESTADO_PEDIDO_ANULADO ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-800') }}">
+                                {{ ucwords(str_replace('_', ' ', $pedido->estado_pedido)) }}
+                            </span>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Tipo de entrega') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ ucwords(str_replace('_', ' ', $pedido->tipo_entrega)) }}</p>
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Monto total') }}</h3>
+                            <p class="mt-1 text-lg text-gray-900">S/ {{ number_format($pedido->monto_total, 2) }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Saldo pendiente') }}</h3>
+                            <p class="mt-1 text-lg text-gray-900">S/ {{ number_format($pedido->saldo_pendiente, 2) }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Vuelto') }}</h3>
+                            <p class="mt-1 text-lg text-gray-900">S/ {{ number_format($cambio, 2) }}</p>
+                        </div>
+                    </div>
+
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-500">{{ __('Notas') }}</h3>
+                        <p class="mt-1 text-gray-900 whitespace-pre-line">{{ $pedido->notas ?: __('Sin notas adicionales') }}</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <h3 class="text-lg font-semibold text-gray-800 mb-4">{{ __('Detalle de productos') }}</h3>
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Producto') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Cantidad') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Metraje') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Subtotal') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($pedido->detalles as $detalle)
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $detalle->producto?->nombre }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $detalle->cantidad }} {{ $detalle->unidad }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $detalle->metraje ?? __('N/A') }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $detalle->subtotal ? 'S/ '.number_format($detalle->subtotal, 2) : __('N/A') }}</td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="4" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No hay productos registrados para este pedido.') }}</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/categorias/_form.blade.php
+++ b/resources/views/categorias/_form.blade.php
@@ -1,0 +1,15 @@
+@csrf
+<div class="space-y-6">
+    <div>
+        <x-input-label for="nombre" value="{{ __('Nombre') }}" />
+        <x-text-input id="nombre" name="nombre" type="text" class="mt-1 block w-full" :value="old('nombre', $categoria->nombre ?? '')" required />
+        <x-input-error :messages="$errors->get('nombre')" class="mt-2" />
+    </div>
+</div>
+
+<div class="flex justify-end space-x-2">
+    <a href="{{ route('categorias.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-300 focus:outline-none focus:border-gray-400 focus:ring ring-gray-200 transition ease-in-out duration-150">
+        {{ __('Cancelar') }}
+    </a>
+    <x-primary-button>{{ $submitLabel }}</x-primary-button>
+</div>

--- a/resources/views/categorias/create.blade.php
+++ b/resources/views/categorias/create.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Nueva categoría') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('categorias.store') }}">
+                    @include('categorias._form', ['submitLabel' => __('Guardar')])
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/categorias/edit.blade.php
+++ b/resources/views/categorias/edit.blade.php
@@ -1,0 +1,19 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Editar categoría') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('categorias.update', $categoria) }}">
+                    @csrf
+                    @method('PUT')
+                    @include('categorias._form', ['submitLabel' => __('Actualizar')])
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/categorias/index.blade.php
+++ b/resources/views/categorias/index.blade.php
@@ -1,0 +1,82 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Categorías') }}
+            </h2>
+            @can('manage categorias')
+                <a href="{{ route('categorias.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:border-indigo-700 focus:ring ring-indigo-200 transition ease-in-out duration-150">
+                    {{ __('Nueva categoría') }}
+                </a>
+            @endcan
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-4">
+                    @if (session('status'))
+                        <div class="rounded-md bg-green-50 p-4 text-sm text-green-700">{{ session('status') }}</div>
+                    @endif
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                        {{ __('Nombre') }}
+                                    </th>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                        {{ __('Fecha de creación') }}
+                                    </th>
+                                    <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                        {{ __('Acciones') }}
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($categorias as $categoria)
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                            <a href="{{ route('categorias.show', $categoria) }}" class="text-indigo-600 hover:text-indigo-900">
+                                                {{ $categoria->nombre }}
+                                            </a>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                            {{ $categoria->created_at?->format('d/m/Y H:i') }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                            @can('manage categorias')
+                                                <a href="{{ route('categorias.edit', $categoria) }}" class="text-indigo-600 hover:text-indigo-900">
+                                                    {{ __('Editar') }}
+                                                </a>
+                                                <form action="{{ route('categorias.destroy', $categoria) }}" method="POST" class="inline" onsubmit="return confirm('{{ __('¿Eliminar esta categoría?') }}');">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="text-red-600 hover:text-red-800">
+                                                        {{ __('Eliminar') }}
+                                                    </button>
+                                                </form>
+                                            @endcan
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="3" class="px-6 py-4 text-center text-sm text-gray-500">
+                                            {{ __('No se encontraron categorías.') }}
+                                        </td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div>
+                        {{ $categorias->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/categorias/show.blade.php
+++ b/resources/views/categorias/show.blade.php
@@ -1,0 +1,35 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ $categoria->nombre }}
+            </h2>
+            <a href="{{ route('categorias.index') }}" class="text-sm text-indigo-600 hover:text-indigo-800">
+                {{ __('Volver al listado') }}
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-4">
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-500">{{ __('Nombre') }}</h3>
+                        <p class="mt-1 text-lg text-gray-900">{{ $categoria->nombre }}</p>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Creado el') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $categoria->created_at?->format('d/m/Y H:i') }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Actualizado el') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $categoria->updated_at?->format('d/m/Y H:i') }}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/cierres/index.blade.php
+++ b/resources/views/cierres/index.blade.php
@@ -1,0 +1,74 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Cierre diario de almacenes') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <form method="GET" class="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
+                        <div>
+                            <x-input-label for="fecha" value="{{ __('Fecha') }}" />
+                            <x-text-input id="fecha" type="date" name="fecha" class="mt-1 block w-full" :value="$fecha" />
+                        </div>
+                        <div>
+                            <x-input-label for="almacen_id" value="{{ __('Almacén') }}" />
+                            <select id="almacen_id" name="almacen_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                <option value="">{{ __('Todos') }}</option>
+                                @foreach ($almacenes as $id => $nombre)
+                                    <option value="{{ $id }}" @selected($almacenId == $id)>{{ $nombre }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="md:col-span-2 flex space-x-2">
+                            <x-primary-button class="self-end">{{ __('Filtrar') }}</x-primary-button>
+                            <a href="{{ route('supervisor.cierres.index') }}" class="self-end inline-flex items-center px-4 py-2 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-300 focus:outline-none focus:border-gray-400 focus:ring ring-gray-200 transition ease-in-out duration-150">{{ __('Limpiar') }}</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-4">
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Fecha') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Almacén') }}</th>
+                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Total ventas') }}</th>
+                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Total pagado') }}</th>
+                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Saldo pendiente') }}</th>
+                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Vuelto') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($cierres as $cierre)
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ \Carbon\Carbon::parse($cierre->fecha)->format('d/m/Y') }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $cierre->almacen_nombre ?? __('Sin destino') }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">S/ {{ number_format($cierre->total_monto, 2) }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">S/ {{ number_format($cierre->total_pagado, 2) }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">S/ {{ number_format($cierre->total_pendiente, 2) }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">S/ {{ number_format($cierre->total_vuelto, 2) }}</td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="6" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No hay información disponible para los filtros seleccionados.') }}</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div>
+                        {{ $cierres->appends(request()->query())->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -12,9 +12,18 @@
 
                 <!-- Navigation Links -->
                 <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
-                    <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                        {{ __('Dashboard') }}
-                    </x-nav-link>
+                    @foreach (config('modules.menus') as $module)
+                        @continue(!isset($module['route'], $module['permission']))
+                        @php
+                            $routeName = $module['route'];
+                            $canView = auth()->user()?->can($module['permission']);
+                        @endphp
+                        @if ($canView && \Illuminate\Support\Facades\Route::has($routeName))
+                            <x-nav-link :href="route($routeName)" :active="request()->routeIs($routeName) || request()->routeIs($routeName.'.*')">
+                                {{ __($module['label']) }}
+                            </x-nav-link>
+                        @endif
+                    @endforeach
                 </div>
             </div>
 
@@ -67,9 +76,18 @@
     <!-- Responsive Navigation Menu -->
     <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
         <div class="pt-2 pb-3 space-y-1">
-            <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                {{ __('Dashboard') }}
-            </x-responsive-nav-link>
+            @foreach (config('modules.menus') as $module)
+                @continue(!isset($module['route'], $module['permission']))
+                @php
+                    $routeName = $module['route'];
+                    $canView = auth()->user()?->can($module['permission']);
+                @endphp
+                @if ($canView && \Illuminate\Support\Facades\Route::has($routeName))
+                    <x-responsive-nav-link :href="route($routeName)" :active="request()->routeIs($routeName) || request()->routeIs($routeName.'.*')">
+                        {{ __($module['label']) }}
+                    </x-responsive-nav-link>
+                @endif
+            @endforeach
         </div>
 
         <!-- Responsive Settings Options -->

--- a/resources/views/pedidos/_form.blade.php
+++ b/resources/views/pedidos/_form.blade.php
@@ -1,0 +1,177 @@
+@csrf
+@php
+    $oldMontoTotal = old('monto_total', $pedido->monto_total ?? 0);
+    $oldMontoPagado = old('monto_pagado', $pedido->monto_pagado ?? 0);
+@endphp
+<div
+    x-data="{
+        montoTotal: {{ is_numeric($oldMontoTotal) ? $oldMontoTotal : 0 }},
+        montoPagado: {{ is_numeric($oldMontoPagado) ? $oldMontoPagado : 0 }},
+        get saldo() {
+            const total = parseFloat(this.montoTotal) || 0;
+            const pagado = parseFloat(this.montoPagado) || 0;
+            const diff = total - pagado;
+            return diff > 0 ? diff : 0;
+        },
+        get vuelto() {
+            const total = parseFloat(this.montoTotal) || 0;
+            const pagado = parseFloat(this.montoPagado) || 0;
+            const diff = pagado - total;
+            return diff > 0 ? diff : 0;
+        }
+    }"
+    class="space-y-6"
+>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+            <x-input-label for="tienda_id" value="{{ __('Tienda') }}" />
+            <select id="tienda_id" name="tienda_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                <option value="">{{ __('Seleccione una tienda') }}</option>
+                @foreach ($tiendas as $id => $nombre)
+                    <option value="{{ $id }}" @selected(old('tienda_id', $pedido->tienda_id ?? '') == $id)>{{ $nombre }}</option>
+                @endforeach
+            </select>
+            <x-input-error :messages="$errors->get('tienda_id')" class="mt-2" />
+        </div>
+        <div>
+            <x-input-label for="vendedor_id" value="{{ __('Vendedor') }}" />
+            <select id="vendedor_id" name="vendedor_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                <option value="">{{ __('Seleccione un vendedor') }}</option>
+                @foreach ($vendedores as $id => $nombre)
+                    <option value="{{ $id }}" @selected(old('vendedor_id', $pedido->vendedor_id ?? '') == $id)>{{ $nombre }}</option>
+                @endforeach
+            </select>
+            <x-input-error :messages="$errors->get('vendedor_id')" class="mt-2" />
+        </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+            <x-input-label for="almacen_id" value="{{ __('Almacén origen') }}" />
+            <select id="almacen_id" name="almacen_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                <option value="">{{ __('Seleccione un almacén') }}</option>
+                @foreach ($almacenes as $id => $nombre)
+                    <option value="{{ $id }}" @selected(old('almacen_id', $pedido->almacen_id ?? '') == $id)>{{ $nombre }}</option>
+                @endforeach
+            </select>
+            <x-input-error :messages="$errors->get('almacen_id')" class="mt-2" />
+        </div>
+        <div>
+            <x-input-label for="almacen_destino_id" value="{{ __('Almacén destino') }}" />
+            <select id="almacen_destino_id" name="almacen_destino_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                <option value="">{{ __('Seleccione un almacén destino') }}</option>
+                @foreach ($almacenes as $id => $nombre)
+                    <option value="{{ $id }}" @selected(old('almacen_destino_id', $pedido->almacen_destino_id ?? '') == $id)>{{ $nombre }}</option>
+                @endforeach
+            </select>
+            <x-input-error :messages="$errors->get('almacen_destino_id')" class="mt-2" />
+        </div>
+    </div>
+
+    <div>
+        <x-input-label for="encargado_id" value="{{ __('Encargado') }}" />
+        <select id="encargado_id" name="encargado_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+            <option value="">{{ __('Seleccione un encargado') }}</option>
+            @foreach ($encargados as $id => $nombre)
+                <option value="{{ $id }}" @selected(old('encargado_id', $pedido->encargado_id ?? '') == $id)>{{ $nombre }}</option>
+            @endforeach
+        </select>
+        <x-input-error :messages="$errors->get('encargado_id')" class="mt-2" />
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div>
+            <x-input-label for="monto_total" value="{{ __('Monto total (S/)') }}" />
+            <x-text-input id="monto_total" name="monto_total" type="number" step="0.01" min="0" class="mt-1 block w-full" x-model.number="montoTotal" :value="$oldMontoTotal" required />
+            <x-input-error :messages="$errors->get('monto_total')" class="mt-2" />
+        </div>
+        <div>
+            <x-input-label for="monto_pagado" value="{{ __('Monto pagado (S/)') }}" />
+            <x-text-input id="monto_pagado" name="monto_pagado" type="number" step="0.01" min="0" class="mt-1 block w-full" x-model.number="montoPagado" :value="$oldMontoPagado" />
+            <x-input-error :messages="$errors->get('monto_pagado')" class="mt-2" />
+        </div>
+        <div class="bg-gray-50 rounded-md border border-dashed border-gray-300 p-4">
+            <p class="text-sm text-gray-600">{{ __('Saldo pendiente') }}:</p>
+            <p class="text-lg font-semibold text-gray-900" x-text="`S/ ${saldo.toFixed(2)}`"></p>
+            <p class="text-sm text-gray-600 mt-2">{{ __('Vuelto estimado') }}:</p>
+            <p class="text-lg font-semibold text-gray-900" x-text="`S/ ${vuelto.toFixed(2)}`"></p>
+        </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div>
+            <x-input-label for="metraje_total" value="{{ __('Metraje total') }}" />
+            <x-text-input id="metraje_total" name="metraje_total" type="number" step="0.01" min="0" class="mt-1 block w-full" :value="old('metraje_total', $pedido->metraje_total ?? '')" />
+            <x-input-error :messages="$errors->get('metraje_total')" class="mt-2" />
+        </div>
+        <div>
+            <x-input-label for="cantidad_total" value="{{ __('Cantidad total') }}" />
+            <x-text-input id="cantidad_total" name="cantidad_total" type="number" step="0.01" min="0" class="mt-1 block w-full" :value="old('cantidad_total', $pedido->cantidad_total ?? '')" />
+            <x-input-error :messages="$errors->get('cantidad_total')" class="mt-2" />
+        </div>
+        <div>
+            <x-input-label for="unidad_referencia" value="{{ __('Unidad referencia') }}" />
+            <x-text-input id="unidad_referencia" name="unidad_referencia" type="text" class="mt-1 block w-full" :value="old('unidad_referencia', $pedido->unidad_referencia ?? '')" />
+            <x-input-error :messages="$errors->get('unidad_referencia')" class="mt-2" />
+        </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div>
+            <x-input-label for="precio_promedio" value="{{ __('Precio promedio (S/)') }}" />
+            <x-text-input id="precio_promedio" name="precio_promedio" type="number" step="0.01" min="0" class="mt-1 block w-full" :value="old('precio_promedio', $pedido->precio_promedio ?? '')" />
+            <x-input-error :messages="$errors->get('precio_promedio')" class="mt-2" />
+        </div>
+        <div>
+            <x-input-label for="tipo_entrega" value="{{ __('Tipo de entrega') }}" />
+            <select id="tipo_entrega" name="tipo_entrega" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                @foreach ($tiposEntrega as $tipo)
+                    <option value="{{ $tipo }}" @selected(old('tipo_entrega', $pedido->tipo_entrega ?? '') === $tipo)>{{ ucwords(str_replace('_', ' ', $tipo)) }}</option>
+                @endforeach
+            </select>
+            <x-input-error :messages="$errors->get('tipo_entrega')" class="mt-2" />
+        </div>
+        <div>
+            <x-input-label for="tipo_pago" value="{{ __('Tipo de pago') }}" />
+            <select id="tipo_pago" name="tipo_pago" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                <option value="">{{ __('Seleccione un tipo de pago') }}</option>
+                @foreach ($tiposPago as $tipo)
+                    <option value="{{ $tipo }}" @selected(old('tipo_pago', $pedido->tipo_pago ?? '') === $tipo)>{{ strtoupper($tipo) }}</option>
+                @endforeach
+            </select>
+            <x-input-error :messages="$errors->get('tipo_pago')" class="mt-2" />
+        </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+            <x-input-label for="estado_pedido" value="{{ __('Estado del pedido') }}" />
+            <select id="estado_pedido" name="estado_pedido" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                @foreach ($estadosPedido as $estado)
+                    <option value="{{ $estado }}" @selected(old('estado_pedido', $pedido->estado_pedido ?? '') === $estado)>{{ ucwords(str_replace('_', ' ', $estado)) }}</option>
+                @endforeach
+            </select>
+            <x-input-error :messages="$errors->get('estado_pedido')" class="mt-2" />
+        </div>
+        <div class="flex items-center pt-6">
+            <label class="inline-flex items-center">
+                <input type="hidden" name="cobra_almacen" value="0">
+                <input type="checkbox" name="cobra_almacen" value="1" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" @checked(old('cobra_almacen', $pedido->cobra_almacen ?? false))>
+                <span class="ms-2 text-sm text-gray-600">{{ __('Cobro en almacén') }}</span>
+            </label>
+        </div>
+    </div>
+
+    <div>
+        <x-input-label for="notas" value="{{ __('Notas') }}" />
+        <textarea id="notas" name="notas" rows="4" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">{{ old('notas', $pedido->notas ?? '') }}</textarea>
+        <x-input-error :messages="$errors->get('notas')" class="mt-2" />
+    </div>
+</div>
+
+<div class="flex justify-end space-x-2 mt-8">
+    <a href="{{ route('supervisor.pedidos.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-300 focus:outline-none focus:border-gray-400 focus:ring ring-gray-200 transition ease-in-out duration-150">
+        {{ __('Cancelar') }}
+    </a>
+    <x-primary-button>{{ $submitLabel }}</x-primary-button>
+</div>

--- a/resources/views/pedidos/create.blade.php
+++ b/resources/views/pedidos/create.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Registrar pedido') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('supervisor.pedidos.store') }}">
+                    @include('pedidos._form', ['submitLabel' => __('Guardar pedido')])
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/pedidos/edit.blade.php
+++ b/resources/views/pedidos/edit.blade.php
@@ -1,0 +1,19 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Actualizar pedido') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('supervisor.pedidos.update', $pedido) }}">
+                    @csrf
+                    @method('PUT')
+                    @include('pedidos._form', ['submitLabel' => __('Actualizar pedido')])
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/pedidos/index.blade.php
+++ b/resources/views/pedidos/index.blade.php
@@ -1,0 +1,81 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Pedidos') }}
+            </h2>
+            @can('manage pedidos')
+                <a href="{{ route('supervisor.pedidos.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:border-indigo-700 focus:ring ring-indigo-200 transition ease-in-out duration-150">
+                    {{ __('Registrar pedido') }}
+                </a>
+            @endcan
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-4">
+                    @if (session('status'))
+                        <div class="rounded-md bg-green-50 p-4 text-sm text-green-700">{{ session('status') }}</div>
+                    @endif
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Código') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Tienda') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Vendedor') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Monto total') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Estado pago') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Estado pedido') }}</th>
+                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Acciones') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($pedidos as $pedido)
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">#{{ $pedido->id }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $pedido->tienda?->nombre }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $pedido->vendedor?->nombre }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">S/ {{ number_format($pedido->monto_total, 2) }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold {{ $pedido->estado_pago === \App\Models\Pedido::ESTADO_PAGO_PAGADO ? 'bg-green-100 text-green-800' : ($pedido->estado_pago === \App\Models\Pedido::ESTADO_PAGO_VUELTO ? 'bg-blue-100 text-blue-800' : 'bg-yellow-100 text-yellow-800') }}">
+                                                {{ __(ucwords(str_replace('_', ' ', $pedido->estado_pago))) }}
+                                            </span>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold {{ $pedido->estado_pedido === \App\Models\Pedido::ESTADO_PEDIDO_ENTREGADO ? 'bg-green-100 text-green-800' : ($pedido->estado_pedido === \App\Models\Pedido::ESTADO_PEDIDO_ANULADO ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-800') }}">
+                                                {{ __(ucwords(str_replace('_', ' ', $pedido->estado_pedido))) }}
+                                            </span>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                            <a href="{{ route('supervisor.pedidos.show', $pedido) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Ver') }}</a>
+                                            @can('manage pedidos')
+                                                <a href="{{ route('supervisor.pedidos.edit', $pedido) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Editar') }}</a>
+                                                <form action="{{ route('supervisor.pedidos.destroy', $pedido) }}" method="POST" class="inline" onsubmit="return confirm('{{ __('¿Eliminar este pedido?') }}');">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="text-red-600 hover:text-red-800">{{ __('Eliminar') }}</button>
+                                                </form>
+                                            @endcan
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="7" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No se encontraron pedidos.') }}</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div>
+                        {{ $pedidos->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/pedidos/show.blade.php
+++ b/resources/views/pedidos/show.blade.php
@@ -1,0 +1,158 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Pedido #:id', ['id' => $pedido->id]) }}
+            </h2>
+            <div class="flex items-center space-x-3">
+                <a href="{{ route('supervisor.pedidos.index') }}" class="text-sm text-indigo-600 hover:text-indigo-800">
+                    {{ __('Volver al listado') }}
+                </a>
+                @can('manage pedidos')
+                    <a href="{{ route('supervisor.pedidos.edit', $pedido) }}" class="text-sm text-indigo-600 hover:text-indigo-800">
+                        {{ __('Editar') }}
+                    </a>
+                @endcan
+            </div>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-6xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            @if (session('status'))
+                <div class="rounded-md bg-green-50 p-4 text-sm text-green-700">{{ session('status') }}</div>
+            @endif
+
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-4">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Tienda') }}</h3>
+                            <p class="mt-1 text-lg text-gray-900">{{ $pedido->tienda?->nombre }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Vendedor') }}</h3>
+                            <p class="mt-1 text-lg text-gray-900">{{ $pedido->vendedor?->nombre }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Almacén origen') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $pedido->almacen?->nombre }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Almacén destino') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $pedido->almacenDestino?->nombre ?? __('Sin destino') }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Encargado') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $pedido->encargado?->name }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Tipo de entrega') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ ucwords(str_replace('_', ' ', $pedido->tipo_entrega)) }}</p>
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div class="rounded-lg border border-gray-200 p-4">
+                            <p class="text-sm text-gray-600">{{ __('Monto total') }}</p>
+                            <p class="text-2xl font-semibold text-gray-900">S/ {{ number_format($pedido->monto_total, 2) }}</p>
+                        </div>
+                        <div class="rounded-lg border border-gray-200 p-4">
+                            <p class="text-sm text-gray-600">{{ __('Monto pagado') }}</p>
+                            <p class="text-2xl font-semibold text-gray-900">S/ {{ number_format($pedido->monto_pagado, 2) }}</p>
+                            <p class="text-sm text-blue-600 mt-1">{{ __('Vuelto registrado') }}: S/ {{ number_format($cambio, 2) }}</p>
+                        </div>
+                        <div class="rounded-lg border border-gray-200 p-4">
+                            <p class="text-sm text-gray-600">{{ __('Saldo pendiente') }}</p>
+                            <p class="text-2xl font-semibold text-gray-900">S/ {{ number_format($pedido->saldo_pendiente, 2) }}</p>
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Estado de pago') }}</h3>
+                            <span class="inline-flex mt-1 items-center px-2 py-1 rounded-full text-xs font-semibold {{ $pedido->estado_pago === \App\Models\Pedido::ESTADO_PAGO_PAGADO ? 'bg-green-100 text-green-800' : ($pedido->estado_pago === \App\Models\Pedido::ESTADO_PAGO_VUELTO ? 'bg-blue-100 text-blue-800' : 'bg-yellow-100 text-yellow-800') }}">
+                                {{ ucwords(str_replace('_', ' ', $pedido->estado_pago)) }}
+                            </span>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Estado del pedido') }}</h3>
+                            <span class="inline-flex mt-1 items-center px-2 py-1 rounded-full text-xs font-semibold {{ $pedido->estado_pedido === \App\Models\Pedido::ESTADO_PEDIDO_ENTREGADO ? 'bg-green-100 text-green-800' : ($pedido->estado_pedido === \App\Models\Pedido::ESTADO_PEDIDO_ANULADO ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-800') }}">
+                                {{ ucwords(str_replace('_', ' ', $pedido->estado_pedido)) }}
+                            </span>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Tipo de pago') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $pedido->tipo_pago ? strtoupper($pedido->tipo_pago) : __('No especificado') }}</p>
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Metraje total') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $pedido->metraje_total ?? __('N/A') }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Cantidad total') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $pedido->cantidad_total ?? __('N/A') }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Unidad referencia') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $pedido->unidad_referencia ?? __('N/A') }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Precio promedio') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $pedido->precio_promedio ? 'S/ '.number_format($pedido->precio_promedio, 2) : __('N/A') }}</p>
+                        </div>
+                    </div>
+
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-500">{{ __('Cobro en almacén') }}</h3>
+                        <p class="mt-1 text-gray-900">{{ $pedido->cobra_almacen ? __('Sí') : __('No') }}</p>
+                    </div>
+
+                    @if ($pedido->notas)
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Notas') }}</h3>
+                            <p class="mt-1 text-gray-900 whitespace-pre-line">{{ $pedido->notas }}</p>
+                        </div>
+                    @endif
+                </div>
+            </div>
+
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <h3 class="text-lg font-semibold text-gray-800 mb-4">{{ __('Detalle de productos') }}</h3>
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Producto') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Cantidad') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Metraje') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Precio unitario') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Subtotal') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($pedido->detalles as $detalle)
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $detalle->producto?->nombre }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $detalle->cantidad }} {{ $detalle->unidad }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $detalle->metraje ?? __('N/A') }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $detalle->precio_unitario ? 'S/ '.number_format($detalle->precio_unitario, 2) : __('N/A') }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $detalle->subtotal ? 'S/ '.number_format($detalle->subtotal, 2) : __('N/A') }}</td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No hay productos registrados para este pedido.') }}</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/productos/_form.blade.php
+++ b/resources/views/productos/_form.blade.php
@@ -1,0 +1,57 @@
+@csrf
+<div class="space-y-6">
+    <div>
+        <x-input-label for="categoria_id" value="{{ __('Categoría') }}" />
+        <select id="categoria_id" name="categoria_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+            <option value="">{{ __('Seleccione una categoría') }}</option>
+            @foreach ($categorias as $id => $nombre)
+                <option value="{{ $id }}" @selected(old('categoria_id', $producto->categoria_id ?? '') == $id)>{{ $nombre }}</option>
+            @endforeach
+        </select>
+        <x-input-error :messages="$errors->get('categoria_id')" class="mt-2" />
+    </div>
+
+    <div>
+        <x-input-label for="nombre" value="{{ __('Nombre') }}" />
+        <x-text-input id="nombre" name="nombre" type="text" class="mt-1 block w-full" :value="old('nombre', $producto->nombre ?? '')" required />
+        <x-input-error :messages="$errors->get('nombre')" class="mt-2" />
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+            <x-input-label for="medida" value="{{ __('Medida') }}" />
+            <x-text-input id="medida" name="medida" type="text" class="mt-1 block w-full" :value="old('medida', $producto->medida ?? '')" />
+            <x-input-error :messages="$errors->get('medida')" class="mt-2" />
+        </div>
+        <div>
+            <x-input-label for="unidad" value="{{ __('Unidad') }}" />
+            <select id="unidad" name="unidad" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                <option value="">{{ __('Seleccione una unidad') }}</option>
+                @foreach ($unidades as $unidad)
+                    <option value="{{ $unidad }}" @selected(old('unidad', $producto->unidad ?? '') === $unidad)>{{ ucfirst($unidad) }}</option>
+                @endforeach
+            </select>
+            <x-input-error :messages="$errors->get('unidad')" class="mt-2" />
+        </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+            <x-input-label for="piezas_por_caja" value="{{ __('Piezas por caja') }}" />
+            <x-text-input id="piezas_por_caja" name="piezas_por_caja" type="number" min="1" class="mt-1 block w-full" :value="old('piezas_por_caja', $producto->piezas_por_caja ?? 1)" required />
+            <x-input-error :messages="$errors->get('piezas_por_caja')" class="mt-2" />
+        </div>
+        <div>
+            <x-input-label for="precio_referencial" value="{{ __('Precio referencial') }}" />
+            <x-text-input id="precio_referencial" name="precio_referencial" type="number" step="0.01" min="0" class="mt-1 block w-full" :value="old('precio_referencial', $producto->precio_referencial ?? '')" required />
+            <x-input-error :messages="$errors->get('precio_referencial')" class="mt-2" />
+        </div>
+    </div>
+</div>
+
+<div class="flex justify-end space-x-2">
+    <a href="{{ route('productos.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-300 focus:outline-none focus:border-gray-400 focus:ring ring-gray-200 transition ease-in-out duration-150">
+        {{ __('Cancelar') }}
+    </a>
+    <x-primary-button>{{ $submitLabel }}</x-primary-button>
+</div>

--- a/resources/views/productos/create.blade.php
+++ b/resources/views/productos/create.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Nuevo producto') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('productos.store') }}">
+                    @include('productos._form', ['submitLabel' => __('Guardar')])
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/productos/edit.blade.php
+++ b/resources/views/productos/edit.blade.php
@@ -1,0 +1,19 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Editar producto') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('productos.update', $producto) }}">
+                    @csrf
+                    @method('PUT')
+                    @include('productos._form', ['submitLabel' => __('Actualizar')])
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/productos/index.blade.php
+++ b/resources/views/productos/index.blade.php
@@ -1,0 +1,78 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Productos') }}
+            </h2>
+            @can('manage productos')
+                <a href="{{ route('productos.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:border-indigo-700 focus:ring ring-indigo-200 transition ease-in-out duration-150">
+                    {{ __('Nuevo producto') }}
+                </a>
+            @endcan
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-4">
+                    @if (session('status'))
+                        <div class="rounded-md bg-green-50 p-4 text-sm text-green-700">{{ session('status') }}</div>
+                    @endif
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Nombre') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Categoría') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Unidad') }}</th>
+                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Precio') }}</th>
+                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Acciones') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($productos as $producto)
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                            <a href="{{ route('productos.show', $producto) }}" class="text-indigo-600 hover:text-indigo-900">
+                                                {{ $producto->nombre }}
+                                            </a>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                            {{ $producto->categoria?->nombre ?? __('Sin categoría') }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                            {{ ucfirst($producto->unidad) }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">
+                                            S/ {{ number_format($producto->precio_referencial, 2) }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                            @can('manage productos')
+                                                <a href="{{ route('productos.edit', $producto) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Editar') }}</a>
+                                                <form action="{{ route('productos.destroy', $producto) }}" method="POST" class="inline" onsubmit="return confirm('{{ __('¿Eliminar este producto?') }}');">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="text-red-600 hover:text-red-800">{{ __('Eliminar') }}</button>
+                                                </form>
+                                            @endcan
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No se encontraron productos.') }}</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div>
+                        {{ $productos->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/productos/show.blade.php
+++ b/resources/views/productos/show.blade.php
@@ -1,0 +1,55 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ $producto->nombre }}
+            </h2>
+            <a href="{{ route('productos.index') }}" class="text-sm text-indigo-600 hover:text-indigo-800">
+                {{ __('Volver al listado') }}
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-5xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-6">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Categoría') }}</h3>
+                            <p class="mt-1 text-lg text-gray-900">{{ $producto->categoria?->nombre ?? __('Sin categoría') }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Unidad') }}</h3>
+                            <p class="mt-1 text-lg text-gray-900">{{ ucfirst($producto->unidad) }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Medida') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $producto->medida ?? __('No especificado') }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Piezas por caja') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $producto->piezas_por_caja }}</p>
+                        </div>
+                    </div>
+
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-500">{{ __('Precio referencial') }}</h3>
+                        <p class="mt-1 text-2xl font-semibold text-gray-900">S/ {{ number_format($producto->precio_referencial, 2) }}</p>
+                    </div>
+
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Creado el') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $producto->created_at?->format('d/m/Y H:i') }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Actualizado el') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $producto->updated_at?->format('d/m/Y H:i') }}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/tiendas/_form.blade.php
+++ b/resources/views/tiendas/_form.blade.php
@@ -1,0 +1,30 @@
+@csrf
+<div class="space-y-6">
+    <div>
+        <x-input-label for="nombre" value="{{ __('Nombre') }}" />
+        <x-text-input id="nombre" name="nombre" type="text" class="mt-1 block w-full" :value="old('nombre', $tienda->nombre ?? '')" required />
+        <x-input-error :messages="$errors->get('nombre')" class="mt-2" />
+    </div>
+    <div>
+        <x-input-label for="sector" value="{{ __('Sector') }}" />
+        <x-text-input id="sector" name="sector" type="text" class="mt-1 block w-full" :value="old('sector', $tienda->sector ?? '')" required />
+        <x-input-error :messages="$errors->get('sector')" class="mt-2" />
+    </div>
+    <div>
+        <x-input-label for="direccion" value="{{ __('Dirección') }}" />
+        <x-text-input id="direccion" name="direccion" type="text" class="mt-1 block w-full" :value="old('direccion', $tienda->direccion ?? '')" required />
+        <x-input-error :messages="$errors->get('direccion')" class="mt-2" />
+    </div>
+    <div>
+        <x-input-label for="telefono" value="{{ __('Teléfono') }}" />
+        <x-text-input id="telefono" name="telefono" type="text" class="mt-1 block w-full" :value="old('telefono', $tienda->telefono ?? '')" required />
+        <x-input-error :messages="$errors->get('telefono')" class="mt-2" />
+    </div>
+</div>
+
+<div class="flex justify-end space-x-2">
+    <a href="{{ route('tiendas.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-300 focus:outline-none focus:border-gray-400 focus:ring ring-gray-200 transition ease-in-out duration-150">
+        {{ __('Cancelar') }}
+    </a>
+    <x-primary-button>{{ $submitLabel }}</x-primary-button>
+</div>

--- a/resources/views/tiendas/create.blade.php
+++ b/resources/views/tiendas/create.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Nueva tienda') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('tiendas.store') }}">
+                    @include('tiendas._form', ['submitLabel' => __('Guardar')])
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/tiendas/edit.blade.php
+++ b/resources/views/tiendas/edit.blade.php
@@ -1,0 +1,19 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Editar tienda') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('tiendas.update', $tienda) }}">
+                    @csrf
+                    @method('PUT')
+                    @include('tiendas._form', ['submitLabel' => __('Actualizar')])
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/tiendas/index.blade.php
+++ b/resources/views/tiendas/index.blade.php
@@ -1,0 +1,68 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Tiendas') }}
+            </h2>
+            @can('manage tiendas')
+                <a href="{{ route('tiendas.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:border-indigo-700 focus:ring ring-indigo-200 transition ease-in-out duration-150">
+                    {{ __('Nueva tienda') }}
+                </a>
+            @endcan
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-4">
+                    @if (session('status'))
+                        <div class="rounded-md bg-green-50 p-4 text-sm text-green-700">{{ session('status') }}</div>
+                    @endif
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Nombre') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Sector') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Teléfono') }}</th>
+                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Acciones') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($tiendas as $tienda)
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                            <a href="{{ route('tiendas.show', $tienda) }}" class="text-indigo-600 hover:text-indigo-900">{{ $tienda->nombre }}</a>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $tienda->sector }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $tienda->telefono }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                            @can('manage tiendas')
+                                                <a href="{{ route('tiendas.edit', $tienda) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Editar') }}</a>
+                                                <form action="{{ route('tiendas.destroy', $tienda) }}" method="POST" class="inline" onsubmit="return confirm('{{ __('¿Eliminar esta tienda?') }}');">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="text-red-600 hover:text-red-800">{{ __('Eliminar') }}</button>
+                                                </form>
+                                            @endcan
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="4" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No se encontraron tiendas.') }}</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div>
+                        {{ $tiendas->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/tiendas/show.blade.php
+++ b/resources/views/tiendas/show.blade.php
@@ -1,0 +1,64 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ $tienda->nombre }}
+            </h2>
+            <a href="{{ route('tiendas.index') }}" class="text-sm text-indigo-600 hover:text-indigo-800">
+                {{ __('Volver al listado') }}
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-5xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-4">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Sector') }}</h3>
+                            <p class="mt-1 text-lg text-gray-900">{{ $tienda->sector }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Teléfono') }}</h3>
+                            <p class="mt-1 text-lg text-gray-900">{{ $tienda->telefono }}</p>
+                        </div>
+                        <div class="md:col-span-2">
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Dirección') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $tienda->direccion }}</p>
+                        </div>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Creado el') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $tienda->created_at?->format('d/m/Y H:i') }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Actualizado el') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $tienda->updated_at?->format('d/m/Y H:i') }}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <h3 class="text-lg font-semibold text-gray-800 mb-4">{{ __('Vendedores asociados') }}</h3>
+                    <div class="space-y-2">
+                        @forelse ($tienda->vendedores as $vendedor)
+                            <div class="flex items-center justify-between rounded-md border border-gray-200 px-4 py-2">
+                                <div>
+                                    <p class="font-medium text-gray-900">{{ $vendedor->nombre }}</p>
+                                    <p class="text-sm text-gray-500">{{ $vendedor->telefono }}</p>
+                                </div>
+                                <a href="{{ route('vendedores.show', $vendedor) }}" class="text-sm text-indigo-600 hover:text-indigo-800">{{ __('Ver detalle') }}</a>
+                            </div>
+                        @empty
+                            <p class="text-sm text-gray-500">{{ __('No hay vendedores registrados para esta tienda.') }}</p>
+                        @endforelse
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/vendedores/_form.blade.php
+++ b/resources/views/vendedores/_form.blade.php
@@ -1,0 +1,30 @@
+@csrf
+<div class="space-y-6">
+    <div>
+        <x-input-label for="tienda_id" value="{{ __('Tienda') }}" />
+        <select id="tienda_id" name="tienda_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+            <option value="">{{ __('Seleccione una tienda') }}</option>
+            @foreach ($tiendas as $id => $nombre)
+                <option value="{{ $id }}" @selected(old('tienda_id', $vendedor->tienda_id ?? '') == $id)>{{ $nombre }}</option>
+            @endforeach
+        </select>
+        <x-input-error :messages="$errors->get('tienda_id')" class="mt-2" />
+    </div>
+    <div>
+        <x-input-label for="nombre" value="{{ __('Nombre') }}" />
+        <x-text-input id="nombre" name="nombre" type="text" class="mt-1 block w-full" :value="old('nombre', $vendedor->nombre ?? '')" required />
+        <x-input-error :messages="$errors->get('nombre')" class="mt-2" />
+    </div>
+    <div>
+        <x-input-label for="telefono" value="{{ __('Teléfono') }}" />
+        <x-text-input id="telefono" name="telefono" type="text" class="mt-1 block w-full" :value="old('telefono', $vendedor->telefono ?? '')" required />
+        <x-input-error :messages="$errors->get('telefono')" class="mt-2" />
+    </div>
+</div>
+
+<div class="flex justify-end space-x-2">
+    <a href="{{ route('vendedores.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-300 focus:outline-none focus:border-gray-400 focus:ring ring-gray-200 transition ease-in-out duration-150">
+        {{ __('Cancelar') }}
+    </a>
+    <x-primary-button>{{ $submitLabel }}</x-primary-button>
+</div>

--- a/resources/views/vendedores/create.blade.php
+++ b/resources/views/vendedores/create.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Nuevo vendedor') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('vendedores.store') }}">
+                    @include('vendedores._form', ['submitLabel' => __('Guardar')])
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/vendedores/edit.blade.php
+++ b/resources/views/vendedores/edit.blade.php
@@ -1,0 +1,19 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Editar vendedor') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('vendedores.update', $vendedor) }}">
+                    @csrf
+                    @method('PUT')
+                    @include('vendedores._form', ['submitLabel' => __('Actualizar')])
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/vendedores/index.blade.php
+++ b/resources/views/vendedores/index.blade.php
@@ -1,0 +1,68 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Vendedores') }}
+            </h2>
+            @can('manage vendedores')
+                <a href="{{ route('vendedores.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:border-indigo-700 focus:ring ring-indigo-200 transition ease-in-out duration-150">
+                    {{ __('Nuevo vendedor') }}
+                </a>
+            @endcan
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-4">
+                    @if (session('status'))
+                        <div class="rounded-md bg-green-50 p-4 text-sm text-green-700">{{ session('status') }}</div>
+                    @endif
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Nombre') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Tienda') }}</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Teléfono') }}</th>
+                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Acciones') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($vendedores as $vendedor)
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                            <a href="{{ route('vendedores.show', $vendedor) }}" class="text-indigo-600 hover:text-indigo-900">{{ $vendedor->nombre }}</a>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $vendedor->tienda?->nombre ?? __('Sin tienda') }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $vendedor->telefono }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                            @can('manage vendedores')
+                                                <a href="{{ route('vendedores.edit', $vendedor) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Editar') }}</a>
+                                                <form action="{{ route('vendedores.destroy', $vendedor) }}" method="POST" class="inline" onsubmit="return confirm('{{ __('¿Eliminar este vendedor?') }}');">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="text-red-600 hover:text-red-800">{{ __('Eliminar') }}</button>
+                                                </form>
+                                            @endcan
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="4" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No se encontraron vendedores.') }}</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div>
+                        {{ $vendedores->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/vendedores/show.blade.php
+++ b/resources/views/vendedores/show.blade.php
@@ -1,0 +1,39 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ $vendedor->nombre }}
+            </h2>
+            <a href="{{ route('vendedores.index') }}" class="text-sm text-indigo-600 hover:text-indigo-800">
+                {{ __('Volver al listado') }}
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-4">
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-500">{{ __('Tienda') }}</h3>
+                        <p class="mt-1 text-lg text-gray-900">{{ $vendedor->tienda?->nombre ?? __('Sin tienda asignada') }}</p>
+                    </div>
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-500">{{ __('Teléfono') }}</h3>
+                        <p class="mt-1 text-lg text-gray-900">{{ $vendedor->telefono }}</p>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Creado el') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $vendedor->created_at?->format('d/m/Y H:i') }}</p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-medium text-gray-500">{{ __('Actualizado el') }}</h3>
+                            <p class="mt-1 text-gray-900">{{ $vendedor->updated_at?->format('d/m/Y H:i') }}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,9 +1,17 @@
 <?php
 
+use App\Http\Controllers\Admin\PermissionsController as AdminPermissionsController;
 use App\Http\Controllers\Admin\RolePermissionController;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
 use App\Http\Controllers\Admin\UserPermissionController;
+use App\Http\Controllers\AlmacenPedidoController;
+use App\Http\Controllers\CategoriaController;
+use App\Http\Controllers\CierreAlmacenController;
+use App\Http\Controllers\PedidoController;
+use App\Http\Controllers\ProductoController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\TiendaController;
+use App\Http\Controllers\VendedorController;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 
@@ -19,15 +27,64 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    Route::resource('categorias', CategoriaController::class)
+        ->only(['index', 'show'])
+        ->middleware('permission:view categorias');
+    Route::resource('categorias', CategoriaController::class)
+        ->only(['create', 'store', 'edit', 'update', 'destroy'])
+        ->middleware('permission:manage categorias');
+
+    Route::resource('productos', ProductoController::class)
+        ->only(['index', 'show'])
+        ->middleware('permission:view productos');
+    Route::resource('productos', ProductoController::class)
+        ->only(['create', 'store', 'edit', 'update', 'destroy'])
+        ->middleware('permission:manage productos');
+
+    Route::resource('tiendas', TiendaController::class)
+        ->only(['index', 'show'])
+        ->middleware('permission:view tiendas');
+    Route::resource('tiendas', TiendaController::class)
+        ->only(['create', 'store', 'edit', 'update', 'destroy'])
+        ->middleware('permission:manage tiendas');
+
+    Route::resource('vendedores', VendedorController::class)
+        ->only(['index', 'show'])
+        ->middleware('permission:view vendedores');
+    Route::resource('vendedores', VendedorController::class)
+        ->only(['create', 'store', 'edit', 'update', 'destroy'])
+        ->middleware('permission:manage vendedores');
 });
 
 Route::middleware(['auth', 'role:Supervisor'])->prefix('admin')->name('admin.')->group(function () {
     Route::get('roles-permissions', [RolePermissionController::class, 'index'])->name('roles.permissions.index');
     Route::put('roles-permissions', [RolePermissionController::class, 'update'])->name('roles.permissions.update');
 
+    Route::get('permissions', [AdminPermissionsController::class, 'index'])->name('permissions.index');
+    Route::put('permissions', [AdminPermissionsController::class, 'update'])->name('permissions.update');
+
     Route::resource('users', AdminUserController::class)->except(['show', 'destroy']);
     Route::get('users/{user}/permissions', [UserPermissionController::class, 'edit'])->name('users.permissions.edit');
     Route::put('users/{user}/permissions', [UserPermissionController::class, 'update'])->name('users.permissions.update');
+});
+
+Route::middleware(['auth', 'role:Supervisor'])->prefix('supervisor')->name('supervisor.')->group(function () {
+    Route::resource('pedidos', PedidoController::class)
+        ->only(['index', 'show'])
+        ->middleware('permission:view pedidos');
+    Route::resource('pedidos', PedidoController::class)
+        ->only(['create', 'store', 'edit', 'update', 'destroy'])
+        ->middleware('permission:manage pedidos');
+
+    Route::get('cierres', [CierreAlmacenController::class, 'index'])
+        ->middleware('permission:view cierres')
+        ->name('cierres.index');
+});
+
+Route::middleware(['auth', 'role:Encargado', 'permission:view pedidos almacenes'])->prefix('almacen')->name('almacen.')->group(function () {
+    Route::get('pedidos', [AlmacenPedidoController::class, 'index'])->name('pedidos.index');
+    Route::get('pedidos/{pedido}', [AlmacenPedidoController::class, 'show'])->name('pedidos.show');
 });
 
 require __DIR__.'/auth.php';
@@ -44,10 +101,3 @@ Route::get('/test', function () {
     ]);
 })->middleware(['auth']);
 
-Route::get('/supervisor', function () {
-    return 'Acceso permitido: Supervisor';
-})->middleware(['auth', 'role:Supervisor'])->name('supervisor');
-
-Route::get('/encargado', function () {
-    return 'Acceso permitido: Encargado';
-})->middleware(['auth', 'role:Encargado'])->name('encargado');

--- a/tests/Feature/ModuleVisibilityTest.php
+++ b/tests/Feature/ModuleVisibilityTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Almacen;
+use App\Models\Pedido;
+use App\Models\Tienda;
+use App\Models\User;
+use App\Models\Vendedor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class ModuleVisibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    public function test_supervisor_sees_assigned_modules(): void
+    {
+        $permissions = [
+            'view dashboard',
+            'view pedidos',
+            'manage pedidos',
+            'view cierres',
+            'view admin permisos',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::firstOrCreate(['name' => $permission, 'guard_name' => 'web']);
+        }
+
+        $role = Role::firstOrCreate(['name' => 'Supervisor', 'guard_name' => 'web']);
+        $role->givePermissionTo($permissions);
+
+        $user = User::factory()->create();
+        $user->assignRole($role);
+
+        $response = $this->actingAs($user)->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertSee('Pedidos', false);
+        $response->assertSee('Cierre Diario', false);
+        $response->assertSee('Permisos', false);
+        $response->assertDontSee('Pedidos de Almacén');
+    }
+
+    public function test_encargado_only_sees_assigned_modules(): void
+    {
+        $permissions = [
+            'view dashboard',
+            'view pedidos almacenes',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::firstOrCreate(['name' => $permission, 'guard_name' => 'web']);
+        }
+
+        $role = Role::firstOrCreate(['name' => 'Encargado', 'guard_name' => 'web']);
+        $role->givePermissionTo($permissions);
+
+        $almacen = Almacen::factory()->create();
+
+        $user = User::factory()->create(['almacen_id' => $almacen->id]);
+        $user->assignRole($role);
+
+        $response = $this->actingAs($user)->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertSee('Pedidos de Almacén', false);
+        $response->assertDontSee('/supervisor/pedidos');
+    }
+
+    public function test_encargado_sees_only_pedidos_for_assigned_almacen(): void
+    {
+        Permission::firstOrCreate(['name' => 'view pedidos almacenes', 'guard_name' => 'web']);
+        Permission::firstOrCreate(['name' => 'view dashboard', 'guard_name' => 'web']);
+
+        $role = Role::firstOrCreate(['name' => 'Encargado', 'guard_name' => 'web']);
+        $role->givePermissionTo(['view pedidos almacenes', 'view dashboard']);
+
+        $almacenUno = Almacen::factory()->create(['nombre' => 'Almacén 1']);
+        $almacenDos = Almacen::factory()->create(['nombre' => 'Almacén 2']);
+
+        $tienda = Tienda::factory()->create();
+        $vendedor = Vendedor::factory()->create(['tienda_id' => $tienda->id]);
+        $encargado = User::factory()->create(['almacen_id' => $almacenUno->id]);
+        $encargado->assignRole($role);
+
+        $pedidoAsignado = Pedido::factory()->create([
+            'tienda_id' => $tienda->id,
+            'vendedor_id' => $vendedor->id,
+            'almacen_id' => $almacenUno->id,
+            'almacen_destino_id' => $almacenUno->id,
+            'encargado_id' => $encargado->id,
+        ]);
+
+        $pedidoExterno = Pedido::factory()->create([
+            'tienda_id' => $tienda->id,
+            'vendedor_id' => $vendedor->id,
+            'almacen_id' => $almacenDos->id,
+            'almacen_destino_id' => $almacenDos->id,
+            'encargado_id' => $encargado->id,
+        ]);
+
+        $response = $this->actingAs($encargado)->get(route('almacen.pedidos.index'));
+
+        $response->assertOk();
+        $response->assertSee('#'.$pedidoAsignado->id, false);
+        $response->assertDontSee('#'.$pedidoExterno->id, false);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,10 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+    }
 }


### PR DESCRIPTION
## Summary
- agregar controladores, FormRequest y vistas Blade para categorías, productos, tiendas y vendedores
- implementar gestión de pedidos para supervisor y almacén con validaciones, cálculo de vuelto y cierre diario
- habilitar administración de permisos por módulo, navegación condicional y pruebas de visibilidad por rol

## Testing
- php artisan test *(advierte ausencia de archivo .env al ejecutar pruebas predeterminadas de Breeze)*

------
https://chatgpt.com/codex/tasks/task_e_68dd91accc048321a32af2aaffe9ca53