### PR TITLE
Add dashboard metrics controller and view updates

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Almacen;
+use App\Models\Cobro;
+use App\Models\Pedido;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as BaseQueryBuilder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class DashboardController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $shouldFilterByWarehouse = $this->shouldFilterByWarehouse($user);
+
+        $pedidosQuery = Pedido::query();
+
+        if ($shouldFilterByWarehouse && $user->almacen_id) {
+            $pedidosQuery->where('almacen_id', $user->almacen_id);
+        }
+
+        $totalesGenerales = (clone $pedidosQuery)
+            ->selectRaw('COUNT(*) as total_pedidos')
+            ->selectRaw('COALESCE(SUM(monto_total), 0) as monto_total')
+            ->selectRaw('COALESCE(SUM(monto_pagado), 0) as monto_pagado')
+            ->selectRaw('COALESCE(SUM(saldo_pendiente), 0) as saldo_pendiente')
+            ->first();
+
+        $pedidosPorEstado = $this->aggregateByEstado(
+            clone $pedidosQuery,
+            'estado_pedido',
+            Pedido::ESTADOS_PEDIDO,
+            [
+                'monto_total' => 'COALESCE(SUM(monto_total), 0)',
+                'monto_pagado' => 'COALESCE(SUM(monto_pagado), 0)',
+            ]
+        );
+
+        $cobrosQuery = Cobro::query()->whereHas('pedido', function ($query) use ($shouldFilterByWarehouse, $user) {
+            /** @var Builder|BaseQueryBuilder $query */
+            if ($shouldFilterByWarehouse && $user->almacen_id) {
+                $query->where('almacen_id', $user->almacen_id);
+            }
+        });
+
+        $resumenPagos = $this->aggregateByEstado(
+            $cobrosQuery,
+            'estado_pago',
+            Cobro::ESTADOS_PAGO,
+            [
+                'monto' => 'COALESCE(SUM(monto), 0)',
+                'monto_pagado' => 'COALESCE(SUM(monto_pagado), 0)',
+            ]
+        );
+
+        $metricasPorAlmacen = $this->metricasPorAlmacen($user, $shouldFilterByWarehouse);
+
+        return view('dashboard', [
+            'totalesGenerales' => [
+                'total_pedidos' => (int) ($totalesGenerales->total_pedidos ?? 0),
+                'monto_total' => (float) ($totalesGenerales->monto_total ?? 0),
+                'monto_pagado' => (float) ($totalesGenerales->monto_pagado ?? 0),
+                'saldo_pendiente' => (float) ($totalesGenerales->saldo_pendiente ?? 0),
+            ],
+            'pedidosPorEstado' => $pedidosPorEstado,
+            'resumenPagos' => $resumenPagos,
+            'metricasPorAlmacen' => $metricasPorAlmacen,
+            'mostrandoGlobal' => ! $shouldFilterByWarehouse,
+        ]);
+    }
+
+    protected function shouldFilterByWarehouse(User $user): bool
+    {
+        if ($user->hasRole('Supervisor')) {
+            return false;
+        }
+
+        return $user->hasRole('Encargado') || (! empty($user->almacen_id) && ! $user->hasRole('Supervisor'));
+    }
+
+    protected function aggregateByEstado($query, string $column, array $estados, array $sumColumns = []): array
+    {
+        $select = [DB::raw('COUNT(*) as total'), $column];
+
+        foreach ($sumColumns as $alias => $expression) {
+            $select[] = DB::raw($expression.' as '.$alias);
+        }
+
+        $resultados = $query
+            ->select($select)
+            ->groupBy($column)
+            ->get()
+            ->keyBy($column);
+
+        $base = [];
+
+        foreach ($estados as $estado) {
+            $base[$estado] = [
+                'total' => 0,
+            ];
+
+            foreach (array_keys($sumColumns) as $alias) {
+                $base[$estado][$alias] = 0.0;
+            }
+        }
+
+        foreach ($resultados as $estado => $row) {
+            $base[$estado]['total'] = (int) $row->total;
+
+            foreach (array_keys($sumColumns) as $alias) {
+                $base[$estado][$alias] = (float) $row->{$alias};
+            }
+        }
+
+        return $base;
+    }
+
+    protected function metricasPorAlmacen(User $user, bool $shouldFilterByWarehouse): Collection
+    {
+        $query = Pedido::query();
+
+        if ($shouldFilterByWarehouse && $user->almacen_id) {
+            $query->where('almacen_id', $user->almacen_id);
+        }
+
+        $agrupados = $query
+            ->select('almacen_id')
+            ->selectRaw('COUNT(*) as total_pedidos')
+            ->selectRaw('COALESCE(SUM(monto_total), 0) as monto_total')
+            ->selectRaw('COALESCE(SUM(monto_pagado), 0) as monto_pagado')
+            ->groupBy('almacen_id')
+            ->get();
+
+        $almacenIds = $agrupados->pluck('almacen_id')->filter()->all();
+        $almacenes = Almacen::whereIn('id', $almacenIds)->get()->keyBy('id');
+
+        return $agrupados->map(function ($row) use ($almacenes) {
+            $almacen = $almacenes->get($row->almacen_id);
+
+            return [
+                'almacen_id' => $row->almacen_id,
+                'almacen' => $almacen?->nombre ?? 'Sin asignar',
+                'total_pedidos' => (int) $row->total_pedidos,
+                'monto_total' => (float) $row->monto_total,
+                'monto_pagado' => (float) $row->monto_pagado,
+                'saldo_pendiente' => (float) round((float) $row->monto_total - (float) $row->monto_pagado, 2),
+            ];
+        })->values();
+    }
+}

--- a/resources/views/components/dashboard/stat-card.blade.php
+++ b/resources/views/components/dashboard/stat-card.blade.php
@@ -1,0 +1,32 @@
+@props([
+    'title' => null,
+    'value' => null,
+    'subtitle' => null,
+    'icon' => null,
+])
+
+<div {{ $attributes->merge(['class' => 'bg-white overflow-hidden shadow rounded-lg']) }}>
+    <div class="p-5">
+        <div class="flex items-center">
+            @if ($icon)
+                <div class="flex-shrink-0">
+                    <span class="inline-flex items-center justify-center h-12 w-12 rounded-md bg-indigo-100 text-indigo-600">
+                        {!! $icon !!}
+                    </span>
+                </div>
+            @endif
+            <div class="{{ $icon ? 'ml-5' : '' }}">
+                <dt class="text-sm font-medium text-gray-500 truncate">{{ $title }}</dt>
+                <dd class="mt-1 text-2xl font-semibold text-gray-900">{{ $value }}</dd>
+                @if ($subtitle)
+                    <p class="mt-2 text-sm text-gray-500">{{ $subtitle }}</p>
+                @endif
+            </div>
+        </div>
+    </div>
+    @if (! $slot->isEmpty())
+        <div class="bg-gray-50 px-5 py-3 text-sm text-gray-500">
+            {{ $slot }}
+        </div>
+    @endif
+</div>

--- a/resources/views/components/dashboard/status-table.blade.php
+++ b/resources/views/components/dashboard/status-table.blade.php
@@ -1,0 +1,55 @@
+@props([
+    'title' => null,
+    'rows' => [],
+    'columns' => [],
+    'emptyMessage' => 'No hay datos disponibles.',
+])
+
+<div {{ $attributes->merge(['class' => 'bg-white shadow rounded-lg']) }}>
+    <div class="px-4 py-5 sm:px-6 border-b border-gray-200">
+        <h3 class="text-lg leading-6 font-medium text-gray-900">{{ $title }}</h3>
+    </div>
+    <div class="px-4 py-5 sm:p-6">
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            Estado
+                        </th>
+                        @foreach ($columns as $column)
+                            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider {{ $column['headerClass'] ?? '' }}">
+                                {{ $column['label'] }}
+                            </th>
+                        @endforeach
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                    @forelse ($rows as $row)
+                        <tr>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                                {{ $row['label'] }}
+                            </td>
+                            @foreach ($columns as $column)
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 {{ $column['class'] ?? '' }}">
+                                    {{ data_get($row['values'], $column['key']) }}
+                                </td>
+                            @endforeach
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="{{ count($columns) + 1 }}" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center">
+                                {{ $emptyMessage }}
+                            </td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        @if (! $slot->isEmpty())
+            <div class="mt-4 text-sm text-gray-500">
+                {{ $slot }}
+            </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,17 +1,146 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Dashboard') }}
-        </h2>
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Panel de control') }}
+            </h2>
+            <span class="inline-flex items-center text-sm text-gray-500">
+                {{ $mostrandoGlobal ? __('Mostrando métricas globales') : __('Métricas filtradas por tu almacén asignado') }}
+            </span>
+        </div>
     </x-slot>
 
+    @php
+        $formatCurrency = fn ($value) => 'S/ '.number_format((float) $value, 2, '.', ',');
+        $formatNumber = fn ($value) => number_format((int) $value, 0, '.', ',');
+
+        $estadoPedidoLabels = [
+            \App\Models\Pedido::ESTADO_PEDIDO_PENDIENTE => __('Pendiente'),
+            \App\Models\Pedido::ESTADO_PEDIDO_EN_CURSO => __('En curso'),
+            \App\Models\Pedido::ESTADO_PEDIDO_ENTREGADO => __('Entregado'),
+            \App\Models\Pedido::ESTADO_PEDIDO_ANULADO => __('Anulado'),
+        ];
+
+        $estadoPagoLabels = [
+            \App\Models\Cobro::ESTADO_PAGO_PENDIENTE => __('Pendiente'),
+            \App\Models\Cobro::ESTADO_PAGO_POR_COBRAR => __('Por cobrar'),
+            \App\Models\Cobro::ESTADO_PAGO_VUELTO => __('Con vuelto'),
+            \App\Models\Cobro::ESTADO_PAGO_PAGADO => __('Pagado'),
+        ];
+
+        $pedidosRows = collect($pedidosPorEstado)->map(function ($values, $estado) use ($estadoPedidoLabels, $formatNumber, $formatCurrency) {
+            $saldo = ($values['monto_total'] ?? 0) - ($values['monto_pagado'] ?? 0);
+
+            return [
+                'label' => $estadoPedidoLabels[$estado] ?? ucfirst(str_replace('_', ' ', $estado)),
+                'values' => [
+                    'total' => $formatNumber($values['total'] ?? 0),
+                    'monto_total' => $formatCurrency($values['monto_total'] ?? 0),
+                    'monto_pagado' => $formatCurrency($values['monto_pagado'] ?? 0),
+                    'saldo' => $formatCurrency($saldo),
+                ],
+            ];
+        })->values()->all();
+
+        $pagosRows = collect($resumenPagos)->map(function ($values, $estado) use ($estadoPagoLabels, $formatNumber, $formatCurrency) {
+            $saldo = ($values['monto'] ?? 0) - ($values['monto_pagado'] ?? 0);
+
+            return [
+                'label' => $estadoPagoLabels[$estado] ?? ucfirst(str_replace('_', ' ', $estado)),
+                'values' => [
+                    'total' => $formatNumber($values['total'] ?? 0),
+                    'monto' => $formatCurrency($values['monto'] ?? 0),
+                    'monto_pagado' => $formatCurrency($values['monto_pagado'] ?? 0),
+                    'saldo' => $formatCurrency($saldo),
+                ],
+            ];
+        })->values()->all();
+
+        $almacenRows = collect($metricasPorAlmacen)->map(function ($row) use ($formatNumber, $formatCurrency) {
+            return [
+                'label' => $row['almacen'] ?? __('Sin asignar'),
+                'values' => [
+                    'total' => $formatNumber($row['total_pedidos'] ?? 0),
+                    'monto_total' => $formatCurrency($row['monto_total'] ?? 0),
+                    'monto_pagado' => $formatCurrency($row['monto_pagado'] ?? 0),
+                    'saldo' => $formatCurrency($row['saldo_pendiente'] ?? 0),
+                ],
+            ];
+        })->all();
+    @endphp
+
     <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900">
-                    {{ __("You're logged in!") }}
-                </div>
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-8">
+            <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+                <x-dashboard.stat-card
+                    :title="__('Pedidos registrados')"
+                    :value="$formatNumber($totalesGenerales['total_pedidos'] ?? 0)"
+                    :subtitle="__('Pedidos capturados en el sistema')"
+                    icon="<svg xmlns='http://www.w3.org/2000/svg' class='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M3 7h18M3 12h18M3 17h18'/></svg>"
+                />
+
+                <x-dashboard.stat-card
+                    :title="__('Monto total')"
+                    :value="$formatCurrency($totalesGenerales['monto_total'] ?? 0)"
+                    :subtitle="__('Ingresos esperados por pedidos')"
+                    icon="<svg xmlns='http://www.w3.org/2000/svg' class='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M12 8c-2.21 0-4 1.343-4 3s1.79 3 4 3 4 1.343 4 3-1.79 3-4 3m0-12c2.21 0 4 1.343 4 3m-4-3V4m0 16v-2'/></svg>"
+                />
+
+                <x-dashboard.stat-card
+                    :title="__('Monto cobrado')"
+                    :value="$formatCurrency($totalesGenerales['monto_pagado'] ?? 0)"
+                    :subtitle="__('Pagos aplicados a pedidos')"
+                    icon="<svg xmlns='http://www.w3.org/2000/svg' class='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M9 12l2 2 4-4m4.5 2a9.5 9.5 0 11-19 0 9.5 9.5 0 0119 0z'/></svg>"
+                />
+
+                <x-dashboard.stat-card
+                    :title="__('Saldo pendiente')"
+                    :value="$formatCurrency(($totalesGenerales['monto_total'] ?? 0) - ($totalesGenerales['monto_pagado'] ?? 0))"
+                    :subtitle="__('Importe restante por cobrar')"
+                    icon="<svg xmlns='http://www.w3.org/2000/svg' class='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M12 6v6l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'/></svg>"
+                />
             </div>
+
+            <div class="grid gap-6 lg:grid-cols-2">
+                <x-dashboard.status-table
+                    :title="__('Pedidos por estado')"
+                    :rows="$pedidosRows"
+                    :columns="[
+                        ['key' => 'total', 'label' => __('Pedidos'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                        ['key' => 'monto_total', 'label' => __('Monto total'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                        ['key' => 'monto_pagado', 'label' => __('Monto cobrado'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                        ['key' => 'saldo', 'label' => __('Saldo pendiente'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                    ]"
+                >
+                    {{ __('Estados consolidados de los pedidos registrados.') }}
+                </x-dashboard.status-table>
+
+                <x-dashboard.status-table
+                    :title="__('Resumen de pagos')"
+                    :rows="$pagosRows"
+                    :columns="[
+                        ['key' => 'total', 'label' => __('Cobros'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                        ['key' => 'monto', 'label' => __('Monto registrado'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                        ['key' => 'monto_pagado', 'label' => __('Monto pagado'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                        ['key' => 'saldo', 'label' => __('Saldo'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                    ]"
+                >
+                    {{ __('Detalle de cobros pendientes y completados según estado de pago.') }}
+                </x-dashboard.status-table>
+            </div>
+
+            <x-dashboard.status-table
+                :title="$mostrandoGlobal ? __('Rendimiento por almacén') : __('Resumen de tu almacén')"
+                :rows="$almacenRows"
+                :columns="[
+                    ['key' => 'total', 'label' => __('Pedidos'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                    ['key' => 'monto_total', 'label' => __('Monto total'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                    ['key' => 'monto_pagado', 'label' => __('Monto cobrado'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                    ['key' => 'saldo', 'label' => __('Saldo pendiente'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                ]"
+            >
+                {{ $mostrandoGlobal ? __('Comparativo de desempeño entre almacenes.') : __('Detalle de movimientos del almacén asignado.') }}
+            </x-dashboard.status-table>
         </div>
     </div>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Admin\UserPermissionController;
 use App\Http\Controllers\AlmacenPedidoController;
 use App\Http\Controllers\CategoriaController;
 use App\Http\Controllers\CierreAlmacenController;
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\PedidoController;
 use App\Http\Controllers\ProductoController;
 use App\Http\Controllers\ProfileController;
@@ -19,9 +20,9 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('/dashboard', function () {
-    return view('dashboard');
-})->middleware(['auth', 'verified', 'permission:view dashboard'])->name('dashboard');
+Route::get('/dashboard', DashboardController::class)
+    ->middleware(['auth', 'verified', 'permission:view dashboard'])
+    ->name('dashboard');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');

--- a/tests/Feature/DashboardControllerTest.php
+++ b/tests/Feature/DashboardControllerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Almacen;
+use App\Models\Cobro;
+use App\Models\Pedido;
+use App\Models\Tienda;
+use App\Models\User;
+use App\Models\Vendedor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class DashboardControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    protected function ensureDashboardPermission(): void
+    {
+        Permission::firstOrCreate(['name' => 'view dashboard', 'guard_name' => 'web']);
+    }
+
+    public function test_supervisor_receives_global_metrics(): void
+    {
+        $this->ensureDashboardPermission();
+
+        $supervisorRole = Role::firstOrCreate(['name' => 'Supervisor', 'guard_name' => 'web']);
+        $supervisorRole->givePermissionTo('view dashboard');
+
+        $supervisor = User::factory()->create();
+        $supervisor->assignRole($supervisorRole);
+
+        $almacenNorte = Almacen::factory()->create(['nombre' => 'Norte']);
+        $almacenSur = Almacen::factory()->create(['nombre' => 'Sur']);
+        $tienda = Tienda::factory()->create();
+        $vendedor = Vendedor::factory()->create(['tienda_id' => $tienda->id]);
+        $encargadoNorte = User::factory()->create(['almacen_id' => $almacenNorte->id]);
+        $encargadoSur = User::factory()->create(['almacen_id' => $almacenSur->id]);
+
+        $pedidoNorte = Pedido::factory()
+            ->for($tienda)
+            ->for($vendedor)
+            ->for($almacenNorte, 'almacen')
+            ->for($almacenNorte, 'almacenDestino')
+            ->for($encargadoNorte, 'encargado')
+            ->create([
+                'monto_total' => 1000,
+                'monto_pagado' => 400,
+                'saldo_pendiente' => 600,
+                'estado_pedido' => Pedido::ESTADO_PEDIDO_EN_CURSO,
+            ]);
+
+        $pedidoSur = Pedido::factory()
+            ->for($tienda)
+            ->for($vendedor)
+            ->for($almacenSur, 'almacen')
+            ->for($almacenSur, 'almacenDestino')
+            ->for($encargadoSur, 'encargado')
+            ->create([
+                'monto_total' => 500,
+                'monto_pagado' => 500,
+                'saldo_pendiente' => 0,
+                'estado_pedido' => Pedido::ESTADO_PEDIDO_ENTREGADO,
+            ]);
+
+        Cobro::factory()->for($pedidoNorte)
+            ->create([
+                'monto' => 400,
+                'monto_pagado' => 200,
+                'estado_pago' => Cobro::ESTADO_PAGO_POR_COBRAR,
+                'tipo_pago' => Cobro::TIPO_PAGO_EFECTIVO,
+                'metodo' => Cobro::TIPO_PAGO_EFECTIVO,
+                'registrado_por' => $encargadoNorte->id,
+            ]);
+
+        Cobro::factory()->for($pedidoSur)
+            ->create([
+                'monto' => 500,
+                'monto_pagado' => 500,
+                'estado_pago' => Cobro::ESTADO_PAGO_PAGADO,
+                'tipo_pago' => Cobro::TIPO_PAGO_EFECTIVO,
+                'metodo' => Cobro::TIPO_PAGO_EFECTIVO,
+                'registrado_por' => $encargadoSur->id,
+            ]);
+
+        $response = $this->actingAs($supervisor)->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertViewHas('mostrandoGlobal', true);
+        $response->assertViewHas('totalesGenerales', function (array $totales): bool {
+            return $totales['total_pedidos'] === 2
+                && abs($totales['monto_total'] - 1500) < 0.01
+                && abs($totales['monto_pagado'] - 900) < 0.01;
+        });
+        $response->assertViewHas('metricasPorAlmacen', function ($metricas) use ($almacenNorte, $almacenSur) {
+            return $metricas->count() === 2
+                && $metricas->contains(fn ($row) => $row['almacen_id'] === $almacenNorte->id && abs($row['monto_total'] - 1000) < 0.01)
+                && $metricas->contains(fn ($row) => $row['almacen_id'] === $almacenSur->id && abs($row['monto_pagado'] - 500) < 0.01);
+        });
+    }
+
+    public function test_encargado_only_sees_metrics_for_their_warehouse(): void
+    {
+        $this->ensureDashboardPermission();
+
+        $encargadoRole = Role::firstOrCreate(['name' => 'Encargado', 'guard_name' => 'web']);
+        $encargadoRole->givePermissionTo('view dashboard');
+
+        $almacenCentral = Almacen::factory()->create(['nombre' => 'Central']);
+        $almacenExterno = Almacen::factory()->create(['nombre' => 'Externo']);
+        $tienda = Tienda::factory()->create();
+        $vendedor = Vendedor::factory()->create(['tienda_id' => $tienda->id]);
+
+        $encargado = User::factory()->create(['almacen_id' => $almacenCentral->id]);
+        $encargado->assignRole($encargadoRole);
+
+        $pedidoCentral = Pedido::factory()
+            ->for($tienda)
+            ->for($vendedor)
+            ->for($almacenCentral, 'almacen')
+            ->for($almacenCentral, 'almacenDestino')
+            ->for($encargado, 'encargado')
+            ->create([
+                'monto_total' => 800,
+                'monto_pagado' => 300,
+                'saldo_pendiente' => 500,
+                'estado_pedido' => Pedido::ESTADO_PEDIDO_EN_CURSO,
+            ]);
+
+        Pedido::factory()
+            ->for($tienda)
+            ->for($vendedor)
+            ->for($almacenExterno, 'almacen')
+            ->for($almacenExterno, 'almacenDestino')
+            ->for(User::factory()->create(['almacen_id' => $almacenExterno->id]), 'encargado')
+            ->create([
+                'monto_total' => 1200,
+                'monto_pagado' => 1200,
+                'saldo_pendiente' => 0,
+                'estado_pedido' => Pedido::ESTADO_PEDIDO_ENTREGADO,
+            ]);
+
+        Cobro::factory()->for($pedidoCentral)
+            ->create([
+                'monto' => 300,
+                'monto_pagado' => 100,
+                'estado_pago' => Cobro::ESTADO_PAGO_POR_COBRAR,
+                'tipo_pago' => Cobro::TIPO_PAGO_EFECTIVO,
+                'metodo' => Cobro::TIPO_PAGO_EFECTIVO,
+                'registrado_por' => $encargado->id,
+            ]);
+
+        $response = $this->actingAs($encargado)->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertViewHas('mostrandoGlobal', false);
+        $response->assertViewHas('totalesGenerales', function (array $totales): bool {
+            return $totales['total_pedidos'] === 1
+                && abs($totales['monto_total'] - 800) < 0.01
+                && abs($totales['monto_pagado'] - 300) < 0.01;
+        });
+        $response->assertViewHas('metricasPorAlmacen', function ($metricas) use ($almacenCentral, $almacenExterno) {
+            return $metricas->count() === 1
+                && $metricas->first()['almacen_id'] === $almacenCentral->id
+                && $metricas->doesntContain(fn ($row) => $row['almacen_id'] === $almacenExterno->id);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a dedicated `DashboardController` that aggregates pedidos, pagos, and almacén metrics with role-aware scoping
- redesign the dashboard view with reusable statistic components and dynamic tables for pedidos and cobros
- add feature tests covering supervisor and encargado visibility rules for the dashboard metrics

## Testing
- php artisan test --testsuite=Feature --filter=DashboardControllerTest

------
https://chatgpt.com/codex/tasks/task_e_68dd95eeee848321b469dbd2c359344e