### PR TITLE
Adjust permission seeding to respect module configuration

### DIFF
--- a/database/seeders/PermissionsSeeder.php
+++ b/database/seeders/PermissionsSeeder.php
@@ -21,8 +21,8 @@ class PermissionsSeeder extends Seeder
 
         $moduleKeys = array_keys($modules);
 
-        collect($moduleKeys)
-            ->map(fn (string $module) => 'view '.$module)
+        collect($modules)
+            ->map(fn (array $module, string $key) => $module['permission'] ?? 'view '.$key)
             ->each(fn (string $permission) => Permission::firstOrCreate([
                 'name' => $permission,
                 'guard_name' => 'web',

--- a/database/seeders/RolesSeeder.php
+++ b/database/seeders/RolesSeeder.php
@@ -12,8 +12,8 @@ class RolesSeeder extends Seeder
         $modules = config('modules.menus');
         $moduleKeys = array_keys($modules);
 
-        $viewPermissions = collect($moduleKeys)
-            ->map(fn (string $module) => 'view '.$module);
+        $viewPermissions = collect($modules)
+            ->map(fn (array $module, string $key) => $module['permission'] ?? 'view '.$key);
 
         $managePermissions = collect(PermissionsSeeder::CRUD_MODULES)
             ->filter(fn (string $module) => in_array($module, $moduleKeys, true))
@@ -29,9 +29,9 @@ class RolesSeeder extends Seeder
         ]);
         $supervisor->syncPermissions($supervisorPermissions);
 
-        $encargadoPermissions = collect(['dashboard', 'productos', 'pedidos', 'cobros'])
+        $encargadoPermissions = collect(['dashboard', 'productos', 'pedidos', 'almacen_pedidos'])
             ->filter(fn (string $module) => array_key_exists($module, $modules))
-            ->map(fn (string $module) => 'view '.$module)
+            ->map(fn (string $module) => $modules[$module]['permission'] ?? 'view '.$module)
             ->all();
 
         $encargado = Role::firstOrCreate([


### PR DESCRIPTION
## Summary
- update the permissions seeder to read module-specific permission names when creating view permissions
- align the roles seeder with the module permissions, explicitly covering the Encargado access to almacen_pedidos and removing stale modules

## Testing
- php artisan migrate:fresh
- php artisan permission:cache-reset
- php artisan db:seed --class=PermissionsSeeder
- php artisan db:seed --class=RolesSeeder
- php artisan tinker --execute="\\App\\Models\\User::factory()->create()->assignRole('Encargado')->hasPermissionTo('view pedidos almacenes') ? print('true') : print('false');"

------
https://chatgpt.com/codex/tasks/task_e_68de135cc93c8321a69d9ee0063b6ca7