### PR TITLE
Preserve manage permissions when updating roles

### DIFF
--- a/app/Http/Controllers/Admin/RolePermissionController.php
+++ b/app/Http/Controllers/Admin/RolePermissionController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\View\View;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
@@ -28,14 +30,47 @@ class RolePermissionController extends Controller
             'roles.*.*' => ['string', 'exists:'.config('permission.table_names.permissions').',name'],
         ]);
 
+        $modulePermissions = $this->modulePermissions();
         $rolesData = $validated['roles'] ?? [];
-        $allRoles = Role::orderBy('id')->get();
+        $allRoles = Role::with('permissions')->orderBy('id')->get();
 
         foreach ($allRoles as $role) {
-            $permissionNames = $rolesData[$role->id] ?? [];
-            $role->syncPermissions($permissionNames);
+            $submitted = collect($rolesData[$role->id] ?? []);
+            $updated = collect($submitted);
+
+            foreach ($modulePermissions as $permissions) {
+                $viewPermission = $permissions['view'] ?? null;
+                $managePermission = $permissions['manage'] ?? null;
+
+                if ($viewPermission && $submitted->contains($viewPermission) && $managePermission) {
+                    $updated->push($managePermission);
+                }
+
+                if ($managePermission && $submitted->contains($managePermission) && $viewPermission && !$submitted->contains($viewPermission)) {
+                    $updated->push($viewPermission);
+                }
+            }
+
+            $role->syncPermissions($updated->unique()->values()->all());
         }
 
         return redirect()->route('admin.roles.permissions.index')->with('status', 'Permisos actualizados correctamente.');
+    }
+
+    private function modulePermissions(): Collection
+    {
+        return collect(config('modules.menus'))
+            ->map(fn (array $module, string $key) => $this->normalizePermissions($module, $key));
+    }
+
+    private function normalizePermissions(array $module, string $moduleKey): array
+    {
+        $permissions = $module['permissions'] ?? [];
+
+        if (!isset($permissions['view'])) {
+            $permissions = ['view' => $module['permission'] ?? 'view '.$moduleKey] + $permissions;
+        }
+
+        return Arr::whereNotNull($permissions);
     }
 }

--- a/config/modules.php
+++ b/config/modules.php
@@ -5,47 +5,70 @@ return [
         'dashboard' => [
             'label' => 'Dashboard',
             'route' => 'dashboard',
-            'permission' => 'view dashboard',
+            'permissions' => [
+                'view' => 'view dashboard',
+            ],
         ],
         'tiendas' => [
             'label' => 'Tiendas',
             'route' => 'tiendas.index',
-            'permission' => 'view tiendas',
+            'permissions' => [
+                'view' => 'view tiendas',
+                'manage' => 'manage tiendas',
+            ],
         ],
         'vendedores' => [
             'label' => 'Vendedores',
             'route' => 'vendedores.index',
-            'permission' => 'view vendedores',
+            'permissions' => [
+                'view' => 'view vendedores',
+                'manage' => 'manage vendedores',
+            ],
         ],
         'categorias' => [
             'label' => 'Categorías',
             'route' => 'categorias.index',
-            'permission' => 'view categorias',
+            'permissions' => [
+                'view' => 'view categorias',
+                'manage' => 'manage categorias',
+            ],
         ],
         'productos' => [
             'label' => 'Productos',
             'route' => 'productos.index',
-            'permission' => 'view productos',
+            'permissions' => [
+                'view' => 'view productos',
+                'manage' => 'manage productos',
+            ],
         ],
         'pedidos' => [
             'label' => 'Pedidos',
             'route' => 'supervisor.pedidos.index',
-            'permission' => 'view pedidos',
+            'permissions' => [
+                'view' => 'view pedidos',
+                'manage' => 'manage pedidos',
+            ],
         ],
         'almacen_pedidos' => [
             'label' => 'Pedidos de Almacén',
             'route' => 'almacen.pedidos.index',
-            'permission' => 'view pedidos almacenes',
+            'permissions' => [
+                'view' => 'view pedidos almacenes',
+            ],
         ],
         'cierres' => [
             'label' => 'Cierre Diario',
             'route' => 'supervisor.cierres.index',
-            'permission' => 'view cierres',
+            'permissions' => [
+                'view' => 'view cierres',
+            ],
         ],
         'admin_permisos' => [
             'label' => 'Permisos',
             'route' => 'admin.permissions.index',
-            'permission' => 'view admin permisos',
+            'permissions' => [
+                'view' => 'view admin permisos',
+            ],
         ],
     ],
 ];

--- a/resources/views/admin/permissions/index.blade.php
+++ b/resources/views/admin/permissions/index.blade.php
@@ -22,19 +22,20 @@
                             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                                 @foreach ($modules as $moduleKey => $module)
                                     @php
-                                        $permissionName = $module['permission'];
+                                        $viewPermission = $module['permissions']['view'] ?? null;
                                     @endphp
+                                    @continue(!$viewPermission)
                                     <label class="flex items-start space-x-2">
-                                    <input
-                                        type="checkbox"
-                                        name="roles[{{ $role->id }}][]"
-                                        value="{{ $permissionName }}"
-                                        class="mt-1 rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
-                                        {{ $role->permissions->contains('name', $permissionName) ? 'checked' : '' }}
-                                    >
+                                        <input
+                                            type="checkbox"
+                                            name="roles[{{ $role->id }}][]"
+                                            value="{{ $viewPermission }}"
+                                            class="mt-1 rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
+                                            {{ $role->permissions->contains('name', $viewPermission) ? 'checked' : '' }}
+                                        >
                                         <span>
                                             <span class="block font-medium text-gray-700">{{ $module['label'] }}</span>
-                                            <span class="block text-xs text-gray-500">{{ $module['route'] }}</span>
+                                            <span class="block text-xs text-gray-500">{{ $module['route'] ?? '' }}</span>
                                         </span>
                                     </label>
                                 @endforeach

--- a/resources/views/admin/roles/index.blade.php
+++ b/resources/views/admin/roles/index.blade.php
@@ -23,21 +23,36 @@
                                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                                     @foreach ($modules as $moduleKey => $module)
                                         @php
-                                            $permissionName = $module['permission'];
+                                            $permissions = $module['permissions'] ?? [];
+                                            $permissionLabels = [
+                                                'view' => __('Ver'),
+                                                'manage' => __('Gestionar'),
+                                            ];
                                         @endphp
-                                        <label class="flex items-start space-x-2">
-                                            <input
-                                                type="checkbox"
-                                                name="roles[{{ $role->id }}][]"
-                                                value="{{ $permissionName }}"
-                                                class="mt-1 rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
-                                                {{ $role->permissions->contains('name', $permissionName) ? 'checked' : '' }}
-                                            >
-                                            <span>
-                                                <span class="block font-medium text-gray-700">{{ $module['label'] }}</span>
-                                                <span class="block text-xs text-gray-500">{{ $module['route'] }}</span>
-                                            </span>
-                                        </label>
+                                        <div class="border border-gray-200 rounded-lg p-4">
+                                            <div class="flex justify-between items-start">
+                                                <div>
+                                                    <span class="block font-medium text-gray-800">{{ $module['label'] }}</span>
+                                                    @isset($module['route'])
+                                                        <span class="block text-xs text-gray-500">{{ $module['route'] }}</span>
+                                                    @endisset
+                                                </div>
+                                            </div>
+                                            <div class="mt-3 space-y-2">
+                                                @foreach ($permissions as $type => $permissionName)
+                                                    <label class="flex items-center space-x-2 text-sm text-gray-700">
+                                                        <input
+                                                            type="checkbox"
+                                                            name="roles[{{ $role->id }}][]"
+                                                            value="{{ $permissionName }}"
+                                                            class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
+                                                            {{ $role->permissions->contains('name', $permissionName) ? 'checked' : '' }}
+                                                        >
+                                                        <span>{{ $permissionLabels[$type] ?? ucfirst($type) }}</span>
+                                                    </label>
+                                                @endforeach
+                                            </div>
+                                        </div>
                                     @endforeach
                                 </div>
                             </div>

--- a/resources/views/admin/users/permissions.blade.php
+++ b/resources/views/admin/users/permissions.blade.php
@@ -19,21 +19,31 @@
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                         @foreach ($modules as $moduleKey => $module)
                             @php
-                                $permissionName = $module['permission'];
+                                $permissionLabels = [
+                                    'view' => __('Ver'),
+                                    'manage' => __('Gestionar'),
+                                ];
                             @endphp
-                            <label class="flex items-start space-x-2">
-                                <input
-                                    type="checkbox"
-                                    name="permissions[]"
-                                    value="{{ $permissionName }}"
-                                    class="mt-1 rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
-                                    {{ in_array($permissionName, $userPermissions, true) ? 'checked' : '' }}
-                                >
-                                <span>
-                                    <span class="block font-medium text-gray-700">{{ $module['label'] }}</span>
+                            <div class="border border-gray-200 rounded-lg p-4">
+                                <span class="block font-medium text-gray-800">{{ $module['label'] }}</span>
+                                @isset($module['route'])
                                     <span class="block text-xs text-gray-500">{{ $module['route'] }}</span>
-                                </span>
-                            </label>
+                                @endisset
+                                <div class="mt-3 space-y-2">
+                                    @foreach (($module['permissions'] ?? []) as $type => $permissionName)
+                                        <label class="flex items-center space-x-2 text-sm text-gray-700">
+                                            <input
+                                                type="checkbox"
+                                                name="permissions[]"
+                                                value="{{ $permissionName }}"
+                                                class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
+                                                {{ in_array($permissionName, $userPermissions, true) ? 'checked' : '' }}
+                                            >
+                                            <span>{{ $permissionLabels[$type] ?? ucfirst($type) }}</span>
+                                        </label>
+                                    @endforeach
+                                </div>
+                            </div>
                         @endforeach
                     </div>
 

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -13,11 +13,12 @@
                 <!-- Navigation Links -->
                 <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
                     @foreach (config('modules.menus') as $module)
-                        @continue(!isset($module['route'], $module['permission']))
                         @php
-                            $routeName = $module['route'];
-                            $canView = auth()->user()?->can($module['permission']);
+                            $routeName = $module['route'] ?? null;
+                            $viewPermission = $module['permissions']['view'] ?? null;
+                            $canView = $routeName && $viewPermission ? auth()->user()?->can($viewPermission) : false;
                         @endphp
+                        @continue(!$routeName || !$viewPermission)
                         @if ($canView && \Illuminate\Support\Facades\Route::has($routeName))
                             <x-nav-link :href="route($routeName)" :active="request()->routeIs($routeName) || request()->routeIs($routeName.'.*')">
                                 {{ __($module['label']) }}
@@ -77,11 +78,12 @@
     <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
         <div class="pt-2 pb-3 space-y-1">
             @foreach (config('modules.menus') as $module)
-                @continue(!isset($module['route'], $module['permission']))
                 @php
-                    $routeName = $module['route'];
-                    $canView = auth()->user()?->can($module['permission']);
+                    $routeName = $module['route'] ?? null;
+                    $viewPermission = $module['permissions']['view'] ?? null;
+                    $canView = $routeName && $viewPermission ? auth()->user()?->can($viewPermission) : false;
                 @endphp
+                @continue(!$routeName || !$viewPermission)
                 @if ($canView && \Illuminate\Support\Facades\Route::has($routeName))
                     <x-responsive-nav-link :href="route($routeName)" :active="request()->routeIs($routeName) || request()->routeIs($routeName.'.*')">
                         {{ __($module['label']) }}

--- a/tests/Feature/Admin/RolePermissionControllerTest.php
+++ b/tests/Feature/Admin/RolePermissionControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Database\Seeders\PermissionsSeeder;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class RolePermissionControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    public function test_supervisor_keeps_manage_permissions_after_updating_roles(): void
+    {
+        $this->seed(PermissionsSeeder::class);
+        $this->seed(RolesSeeder::class);
+
+        /** @var Role $supervisorRole */
+        $supervisorRole = Role::where('name', 'Supervisor')->firstOrFail();
+        $supervisor = User::factory()->create();
+        $supervisor->assignRole($supervisorRole);
+
+        $viewPermissions = collect(config('modules.menus'))
+            ->map(fn (array $module) => $module['permissions']['view'] ?? null)
+            ->filter()
+            ->values()
+            ->all();
+
+        $response = $this->actingAs($supervisor)->put(route('admin.roles.permissions.update'), [
+            'roles' => [
+                $supervisorRole->id => $viewPermissions,
+            ],
+        ]);
+
+        $response->assertRedirect(route('admin.roles.permissions.index'));
+
+        $supervisorRole->refresh();
+
+        foreach (PermissionsSeeder::CRUD_MODULES as $module) {
+            $this->assertTrue(
+                $supervisorRole->hasPermissionTo('manage '.$module),
+                sprintf('Failed asserting that the supervisor keeps the manage %s permission.', $module)
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- map each module to both its view and manage permissions so admin interfaces can render paired checkboxes
- ensure role and permission updates keep manage permissions aligned with view selections and update relevant seeders
- add regression coverage verifying the Supervisor role retains manage permissions after saving

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68de165e83808321a2a5d2e99c0d6a60