### PR TITLE
Fix admin roles menu route

### DIFF
--- a/config/modules.php
+++ b/config/modules.php
@@ -72,7 +72,7 @@ return [
         ],
         'admin_roles' => [
             'label' => 'Roles',
-            'route' => 'admin.roles.index',
+            'route' => 'admin.roles.permissions.index',
             'permissions' => [
                 'view' => 'view admin roles',
                 'manage' => 'manage admin roles',


### PR DESCRIPTION
## Summary
- update the admin roles menu configuration to point to the existing roles permissions route

## Testing
- php artisan config:clear (fails: missing vendor/autoload.php)


------
https://chatgpt.com/codex/tasks/task_e_68de23c8e75883219f5a0598cd5dd960