### PR TITLE
Enhance CRUD action buttons in catalog indexes

### DIFF
--- a/resources/views/categorias/index.blade.php
+++ b/resources/views/categorias/index.blade.php
@@ -5,8 +5,9 @@
                 {{ __('Categorías') }}
             </h2>
             @can('manage categorias')
-                <a href="{{ route('categorias.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:border-indigo-700 focus:ring ring-indigo-200 transition ease-in-out duration-150">
-                    {{ __('Nueva categoría') }}
+                <a href="{{ route('categorias.create') }}"
+                    class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                    {{ __('Agregar categoría') }}
                 </a>
             @endcan
         </div>
@@ -46,18 +47,23 @@
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                                             {{ $categoria->created_at?->format('d/m/Y H:i') }}
                                         </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
                                             @can('manage categorias')
-                                                <a href="{{ route('categorias.edit', $categoria) }}" class="text-indigo-600 hover:text-indigo-900">
-                                                    {{ __('Editar') }}
-                                                </a>
-                                                <form action="{{ route('categorias.destroy', $categoria) }}" method="POST" class="inline" onsubmit="return confirm('{{ __('¿Eliminar esta categoría?') }}');">
-                                                    @csrf
-                                                    @method('DELETE')
-                                                    <button type="submit" class="text-red-600 hover:text-red-800">
-                                                        {{ __('Eliminar') }}
-                                                    </button>
-                                                </form>
+                                                <div class="flex items-center justify-end gap-2">
+                                                    <a href="{{ route('categorias.edit', $categoria) }}"
+                                                        class="inline-flex items-center rounded-md border border-indigo-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-indigo-600 transition duration-150 ease-in-out hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                                                        {{ __('Actualizar') }}
+                                                    </a>
+                                                    <form action="{{ route('categorias.destroy', $categoria) }}" method="POST"
+                                                        onsubmit="return confirm('{{ __('¿Eliminar esta categoría?') }}');">
+                                                        @csrf
+                                                        @method('DELETE')
+                                                        <button type="submit"
+                                                            class="inline-flex items-center rounded-md border border-red-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-red-600 transition duration-150 ease-in-out hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
+                                                            {{ __('Eliminar') }}
+                                                        </button>
+                                                    </form>
+                                                </div>
                                             @endcan
                                         </td>
                                     </tr>

--- a/resources/views/productos/index.blade.php
+++ b/resources/views/productos/index.blade.php
@@ -5,8 +5,9 @@
                 {{ __('Productos') }}
             </h2>
             @can('manage productos')
-                <a href="{{ route('productos.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:border-indigo-700 focus:ring ring-indigo-200 transition ease-in-out duration-150">
-                    {{ __('Nuevo producto') }}
+                <a href="{{ route('productos.create') }}"
+                    class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                    {{ __('Agregar producto') }}
                 </a>
             @endcan
         </div>
@@ -48,14 +49,23 @@
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">
                                             S/ {{ number_format($producto->precio_referencial, 2) }}
                                         </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
                                             @can('manage productos')
-                                                <a href="{{ route('productos.edit', $producto) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Editar') }}</a>
-                                                <form action="{{ route('productos.destroy', $producto) }}" method="POST" class="inline" onsubmit="return confirm('{{ __('¿Eliminar este producto?') }}');">
-                                                    @csrf
-                                                    @method('DELETE')
-                                                    <button type="submit" class="text-red-600 hover:text-red-800">{{ __('Eliminar') }}</button>
-                                                </form>
+                                                <div class="flex items-center justify-end gap-2">
+                                                    <a href="{{ route('productos.edit', $producto) }}"
+                                                        class="inline-flex items-center rounded-md border border-indigo-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-indigo-600 transition duration-150 ease-in-out hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                                                        {{ __('Actualizar') }}
+                                                    </a>
+                                                    <form action="{{ route('productos.destroy', $producto) }}" method="POST"
+                                                        onsubmit="return confirm('{{ __('¿Eliminar este producto?') }}');">
+                                                        @csrf
+                                                        @method('DELETE')
+                                                        <button type="submit"
+                                                            class="inline-flex items-center rounded-md border border-red-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-red-600 transition duration-150 ease-in-out hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
+                                                            {{ __('Eliminar') }}
+                                                        </button>
+                                                    </form>
+                                                </div>
                                             @endcan
                                         </td>
                                     </tr>

--- a/resources/views/tiendas/index.blade.php
+++ b/resources/views/tiendas/index.blade.php
@@ -5,8 +5,9 @@
                 {{ __('Tiendas') }}
             </h2>
             @can('manage tiendas')
-                <a href="{{ route('tiendas.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:border-indigo-700 focus:ring ring-indigo-200 transition ease-in-out duration-150">
-                    {{ __('Nueva tienda') }}
+                <a href="{{ route('tiendas.create') }}"
+                    class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                    {{ __('Agregar tienda') }}
                 </a>
             @endcan
         </div>
@@ -38,14 +39,23 @@
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $tienda->sector }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $tienda->telefono }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
                                             @can('manage tiendas')
-                                                <a href="{{ route('tiendas.edit', $tienda) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Editar') }}</a>
-                                                <form action="{{ route('tiendas.destroy', $tienda) }}" method="POST" class="inline" onsubmit="return confirm('{{ __('¿Eliminar esta tienda?') }}');">
-                                                    @csrf
-                                                    @method('DELETE')
-                                                    <button type="submit" class="text-red-600 hover:text-red-800">{{ __('Eliminar') }}</button>
-                                                </form>
+                                                <div class="flex items-center justify-end gap-2">
+                                                    <a href="{{ route('tiendas.edit', $tienda) }}"
+                                                        class="inline-flex items-center rounded-md border border-indigo-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-indigo-600 transition duration-150 ease-in-out hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                                                        {{ __('Actualizar') }}
+                                                    </a>
+                                                    <form action="{{ route('tiendas.destroy', $tienda) }}" method="POST"
+                                                        onsubmit="return confirm('{{ __('¿Eliminar esta tienda?') }}');">
+                                                        @csrf
+                                                        @method('DELETE')
+                                                        <button type="submit"
+                                                            class="inline-flex items-center rounded-md border border-red-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-red-600 transition duration-150 ease-in-out hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
+                                                            {{ __('Eliminar') }}
+                                                        </button>
+                                                    </form>
+                                                </div>
                                             @endcan
                                         </td>
                                     </tr>

--- a/resources/views/vendedores/index.blade.php
+++ b/resources/views/vendedores/index.blade.php
@@ -5,8 +5,9 @@
                 {{ __('Vendedores') }}
             </h2>
             @can('manage vendedores')
-                <a href="{{ route('vendedores.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:border-indigo-700 focus:ring ring-indigo-200 transition ease-in-out duration-150">
-                    {{ __('Nuevo vendedor') }}
+                <a href="{{ route('vendedores.create') }}"
+                    class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                    {{ __('Agregar vendedor') }}
                 </a>
             @endcan
         </div>
@@ -38,14 +39,23 @@
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $vendedor->tienda?->nombre ?? __('Sin tienda') }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $vendedor->telefono }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
                                             @can('manage vendedores')
-                                                <a href="{{ route('vendedores.edit', $vendedor) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Editar') }}</a>
-                                                <form action="{{ route('vendedores.destroy', $vendedor) }}" method="POST" class="inline" onsubmit="return confirm('{{ __('¿Eliminar este vendedor?') }}');">
-                                                    @csrf
-                                                    @method('DELETE')
-                                                    <button type="submit" class="text-red-600 hover:text-red-800">{{ __('Eliminar') }}</button>
-                                                </form>
+                                                <div class="flex items-center justify-end gap-2">
+                                                    <a href="{{ route('vendedores.edit', $vendedor) }}"
+                                                        class="inline-flex items-center rounded-md border border-indigo-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-indigo-600 transition duration-150 ease-in-out hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                                                        {{ __('Actualizar') }}
+                                                    </a>
+                                                    <form action="{{ route('vendedores.destroy', $vendedor) }}" method="POST"
+                                                        onsubmit="return confirm('{{ __('¿Eliminar este vendedor?') }}');">
+                                                        @csrf
+                                                        @method('DELETE')
+                                                        <button type="submit"
+                                                            class="inline-flex items-center rounded-md border border-red-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-red-600 transition duration-150 ease-in-out hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
+                                                            {{ __('Eliminar') }}
+                                                        </button>
+                                                    </form>
+                                                </div>
                                             @endcan
                                         </td>
                                     </tr>


### PR DESCRIPTION
## Summary
- restyled the add buttons on category, product, store, and vendor listings for clearer visibility
- updated action columns to render explicit update and delete buttons with consistent styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd7e417bf08321ae4973167176611a