### PR TITLE
Actualizar layout principal con estructura TailAdmin

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,23 +14,34 @@
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
-    <body class="font-sans antialiased">
-        <div class="min-h-screen bg-gray-100">
-            @include('layouts.navigation')
+    <body class="font-sans antialiased bg-slate-100" x-data="{ sidebarOpen: false }">
+        <div class="flex min-h-screen overflow-hidden">
+            <div
+                class="fixed inset-0 z-20 bg-slate-900/50 backdrop-blur-sm transition-opacity duration-300 lg:hidden"
+                x-show="sidebarOpen"
+                x-transition.opacity
+                @click="sidebarOpen = false"
+            ></div>
 
-            <!-- Page Heading -->
-            @isset($header)
-                <header class="bg-white shadow">
-                    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-                        {{ $header }}
+            @include('layouts.includes.sidebar')
+
+            <div class="relative flex flex-1 flex-col overflow-y-auto overflow-x-hidden">
+                @include('layouts.includes.topbar')
+
+                <main class="flex-1">
+                    <div class="mx-auto w-full max-w-screen-2xl px-4 py-6 sm:px-6 md:px-8 2xl:px-12">
+                        @isset($header)
+                            <div class="mb-6 flex flex-col gap-4 rounded-xl border border-slate-200 bg-white/80 p-5 shadow-sm backdrop-blur lg:flex-row lg:items-center lg:justify-between">
+                                {{ $header }}
+                            </div>
+                        @endisset
+
+                        <section class="space-y-6">
+                            {{ $slot }}
+                        </section>
                     </div>
-                </header>
-            @endisset
-
-            <!-- Page Content -->
-            <main>
-                {{ $slot }}
-            </main>
+                </main>
+            </div>
         </div>
     </body>
 </html>

--- a/resources/views/layouts/includes/sidebar.blade.php
+++ b/resources/views/layouts/includes/sidebar.blade.php
@@ -1,0 +1,38 @@
+<aside
+    class="fixed inset-y-0 left-0 z-30 flex w-72 flex-col bg-slate-900 text-slate-100 shadow-xl transition-transform duration-300 ease-in-out lg:static lg:translate-x-0"
+    :class="sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'"
+>
+    <div class="flex items-center gap-3 px-6 py-6">
+        <a href="{{ route('dashboard') }}" class="flex items-center gap-3">
+            <x-application-logo class="h-9 w-auto fill-current text-slate-100" />
+            <span class="text-lg font-semibold tracking-tight">{{ config('app.name', 'Laravel') }}</span>
+        </a>
+    </div>
+    <div class="flex-1 overflow-y-auto px-4 pb-8">
+        <nav class="space-y-1">
+            @foreach (config('modules.menus') as $module)
+                @php
+                    $routeName = $module['route'] ?? null;
+                    $viewPermission = $module['permissions']['view'] ?? null;
+                    $user = auth()->user();
+                    $canView = $routeName && $viewPermission ? $user?->can($viewPermission) : false;
+                    $isActive = $routeName ? request()->routeIs($routeName) || request()->routeIs($routeName . '.*') : false;
+                @endphp
+                @continue(!$routeName || !$viewPermission)
+                @if ($canView && \Illuminate\Support\Facades\Route::has($routeName))
+                    <a
+                        href="{{ route($routeName) }}"
+                        class="group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-150 {{
+                            $isActive
+                                ? 'bg-slate-800 text-white shadow-sm'
+                                : 'text-slate-200 hover:bg-slate-800 hover:text-white'
+                        }}"
+                    >
+                        <span class="h-2 w-2 rounded-full border border-white/40 bg-white/40 transition group-hover:bg-white"></span>
+                        <span>{{ __($module['label']) }}</span>
+                    </a>
+                @endif
+            @endforeach
+        </nav>
+    </div>
+</aside>

--- a/resources/views/layouts/includes/topbar.blade.php
+++ b/resources/views/layouts/includes/topbar.blade.php
@@ -1,0 +1,54 @@
+<header class="sticky top-0 z-20 flex w-full items-center justify-between border-b border-slate-200 bg-white px-4 py-4 shadow-sm lg:px-6">
+    <div class="flex items-center gap-3">
+        <button
+            type="button"
+            class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-slate-200 text-slate-500 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-1 lg:hidden"
+            @click.stop="sidebarOpen = !sidebarOpen"
+        >
+            <span class="sr-only">{{ __('Toggle sidebar') }}</span>
+            <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 6h16"></path>
+                <path d="M4 12h16"></path>
+                <path d="M4 18h16"></path>
+            </svg>
+        </button>
+        <div class="hidden text-sm font-medium text-slate-500 lg:block">
+            {{ now()->translatedFormat('l, d \d\e F') }}
+        </div>
+    </div>
+    <div class="flex items-center gap-4">
+        <div class="hidden items-center gap-3 rounded-full border border-slate-200 px-4 py-2 text-sm text-slate-400 sm:flex">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="11" cy="11" r="7"></circle>
+                <path d="m20 20-3.5-3.5"></path>
+            </svg>
+            <span>{{ __('Buscar...') }}</span>
+        </div>
+        <x-dropdown align="right" width="48">
+            <x-slot name="trigger">
+                <button class="flex items-center gap-3 rounded-full border border-slate-200 bg-white px-3 py-2 text-left text-sm font-medium text-slate-600 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-1">
+                    <div class="flex flex-col leading-tight">
+                        <span class="font-semibold text-slate-700">{{ Auth::user()->name }}</span>
+                        <span class="text-xs text-slate-400">{{ Auth::user()->email }}</span>
+                    </div>
+                    <svg class="h-4 w-4 text-slate-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.061l-4.24 4.24a.75.75 0 01-1.06 0l-4.25-4.25a.75.75 0 01.01-1.06z" clip-rule="evenodd" />
+                    </svg>
+                </button>
+            </x-slot>
+
+            <x-slot name="content">
+                <x-dropdown-link :href="route('profile.edit')">
+                    {{ __('Profile') }}
+                </x-dropdown-link>
+
+                <form method="POST" action="{{ route('logout') }}">
+                    @csrf
+                    <x-dropdown-link :href="route('logout')" onclick="event.preventDefault(); this.closest('form').submit();">
+                        {{ __('Log Out') }}
+                    </x-dropdown-link>
+                </form>
+            </x-slot>
+        </x-dropdown>
+    </div>
+</header>


### PR DESCRIPTION
## Summary
- reemplazar el layout base por la estructura de TailAdmin con wrapper responsivo
- añadir sidebar y topbar como includes reutilizables alineados con la paleta TailAdmin
- mantener el slot principal y el bloque opcional de encabezado dentro del contenedor principal

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68de36fc46f083219b2d1713bc074b77