### PR TITLE
Align dashboard components with TailAdmin styles

### DIFF
--- a/resources/views/components/danger-button.blade.php
+++ b/resources/views/components/danger-button.blade.php
@@ -1,3 +1,10 @@
-<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-500 active:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition ease-in-out duration-150']) }}>
+<button
+    {{
+        $attributes->merge([
+            'type' => 'submit',
+            'class' => 'inline-flex items-center justify-center gap-2 rounded-xl bg-rose-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition-colors duration-150 hover:bg-rose-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500/70 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60',
+        ])
+    }}
+>
     {{ $slot }}
 </button>

--- a/resources/views/components/dashboard/stat-card.blade.php
+++ b/resources/views/components/dashboard/stat-card.blade.php
@@ -3,29 +3,72 @@
     'value' => null,
     'subtitle' => null,
     'icon' => null,
+    'badge' => null,
+    'badgeColor' => 'primary',
+    'iconClasses' => 'bg-indigo-100 text-indigo-600',
 ])
 
-<div {{ $attributes->merge(['class' => 'bg-white overflow-hidden shadow rounded-lg']) }}>
-    <div class="p-5">
-        <div class="flex items-center">
-            @if ($icon)
-                <div class="flex-shrink-0">
-                    <span class="inline-flex items-center justify-center h-12 w-12 rounded-md bg-indigo-100 text-indigo-600">
-                        {!! $icon !!}
-                    </span>
+@php
+    use Illuminate\View\ComponentSlot;
+
+    $iconContent = $icon instanceof ComponentSlot ? $icon->toHtml() : $icon;
+    $hasIcon = filled(trim((string) $iconContent ?? ''));
+
+    $badgeContent = $badge instanceof ComponentSlot ? $badge->toHtml() : $badge;
+    $hasBadge = filled(trim((string) $badgeContent ?? ''));
+
+    $badgePalettes = [
+        'primary' => 'bg-indigo-100 text-indigo-600',
+        'success' => 'bg-emerald-100 text-emerald-600',
+        'warning' => 'bg-amber-100 text-amber-600',
+        'danger' => 'bg-rose-100 text-rose-600',
+        'info' => 'bg-sky-100 text-sky-600',
+    ];
+
+    $badgeClasses = $badgePalettes[$badgeColor] ?? $badgePalettes['primary'];
+@endphp
+
+<div
+    {{
+        $attributes->merge([
+            'class' => 'group rounded-2xl border border-slate-200 bg-white/95 p-6 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md',
+        ])
+    }}
+>
+    <div class="flex items-start justify-between gap-4">
+        <div class="flex items-center gap-4">
+            @if ($hasIcon)
+                <div class="flex h-14 w-14 items-center justify-center rounded-full {{ $iconClasses }}">
+                    {!! $iconContent !!}
                 </div>
             @endif
-            <div class="{{ $icon ? 'ml-5' : '' }}">
-                <dt class="text-sm font-medium text-gray-500 truncate">{{ $title }}</dt>
-                <dd class="mt-1 text-2xl font-semibold text-gray-900">{{ $value }}</dd>
+
+            <div class="flex-1 space-y-2">
+                @if ($title)
+                    <p class="text-sm font-medium text-slate-500">{{ $title }}</p>
+                @endif
+
+                <div class="flex flex-wrap items-center gap-3">
+                    @isset($value)
+                        <p class="text-2xl font-semibold text-slate-900">{{ $value }}</p>
+                    @endisset
+
+                    @if ($hasBadge)
+                        <span class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold {{ $badgeClasses }}">
+                            {!! $badgeContent !!}
+                        </span>
+                    @endif
+                </div>
+
                 @if ($subtitle)
-                    <p class="mt-2 text-sm text-gray-500">{{ $subtitle }}</p>
+                    <p class="text-sm text-slate-500">{{ $subtitle }}</p>
                 @endif
             </div>
         </div>
     </div>
+
     @if (! $slot->isEmpty())
-        <div class="bg-gray-50 px-5 py-3 text-sm text-gray-500">
+        <div class="mt-5 border-t border-slate-200 pt-4 text-sm text-slate-500">
             {{ $slot }}
         </div>
     @endif

--- a/resources/views/components/dashboard/status-table.blade.php
+++ b/resources/views/components/dashboard/status-table.blade.php
@@ -5,51 +5,69 @@
     'emptyMessage' => 'No hay datos disponibles.',
 ])
 
-<div {{ $attributes->merge(['class' => 'bg-white shadow rounded-lg']) }}>
-    <div class="px-4 py-5 sm:px-6 border-b border-gray-200">
-        <h3 class="text-lg leading-6 font-medium text-gray-900">{{ $title }}</h3>
+<div
+    {{
+        $attributes->merge([
+            'class' => 'flex flex-col rounded-2xl border border-slate-200 bg-white shadow-sm',
+        ])
+    }}
+>
+    <div class="border-b border-slate-200 px-6 py-5">
+        @if ($title)
+            <h3 class="text-lg font-semibold text-slate-900">{{ $title }}</h3>
+        @endif
+
+        @if (! $slot->isEmpty())
+            <p class="mt-2 text-sm text-slate-500">
+                {{ $slot }}
+            </p>
+        @endif
     </div>
-    <div class="px-4 py-5 sm:p-6">
-        <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
-                    <tr>
-                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                            Estado
-                        </th>
-                        @foreach ($columns as $column)
-                            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider {{ $column['headerClass'] ?? '' }}">
-                                {{ $column['label'] }}
-                            </th>
-                        @endforeach
-                    </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                    @forelse ($rows as $row)
+
+    <div class="px-2 pb-6 pt-4 sm:px-4">
+        <div class="overflow-hidden">
+            <div class="max-w-full overflow-x-auto">
+                <table class="min-w-full divide-y divide-slate-200 text-left text-sm">
+                    <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
                         <tr>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                                {{ $row['label'] }}
-                            </td>
+                            <th scope="col" class="whitespace-nowrap px-6 py-3 text-left">
+                                {{ __('Estado') }}
+                            </th>
                             @foreach ($columns as $column)
-                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 {{ $column['class'] ?? '' }}">
-                                    {{ data_get($row['values'], $column['key']) }}
-                                </td>
+                                <th
+                                    scope="col"
+                                    class="whitespace-nowrap px-6 py-3 {{ $column['headerClass'] ?? 'text-left' }}"
+                                >
+                                    {{ $column['label'] }}
+                                </th>
                             @endforeach
                         </tr>
-                    @empty
-                        <tr>
-                            <td colspan="{{ count($columns) + 1 }}" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center">
-                                {{ $emptyMessage }}
-                            </td>
-                        </tr>
-                    @endforelse
-                </tbody>
-            </table>
-        </div>
-        @if (! $slot->isEmpty())
-            <div class="mt-4 text-sm text-gray-500">
-                {{ $slot }}
+                    </thead>
+                    <tbody class="divide-y divide-slate-200 bg-white">
+                        @forelse ($rows as $row)
+                            <tr class="odd:bg-white even:bg-slate-50 hover:bg-slate-100/70">
+                                <td class="whitespace-nowrap px-6 py-4 text-sm font-semibold text-slate-700">
+                                    {{ $row['label'] }}
+                                </td>
+                                @foreach ($columns as $column)
+                                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600 {{ $column['class'] ?? '' }}">
+                                        {{ data_get($row['values'], $column['key']) }}
+                                    </td>
+                                @endforeach
+                            </tr>
+                        @empty
+                            <tr>
+                                <td
+                                    colspan="{{ count($columns) + 1 }}"
+                                    class="whitespace-nowrap px-6 py-4 text-center text-sm text-slate-500"
+                                >
+                                    {{ $emptyMessage }}
+                                </td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
             </div>
-        @endif
+        </div>
     </div>
 </div>

--- a/resources/views/components/dropdown-link.blade.php
+++ b/resources/views/components/dropdown-link.blade.php
@@ -1,7 +1,7 @@
 <a
     {{
         $attributes->merge([
-            'class' => 'flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium text-slate-600 transition-colors duration-150 hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400',
+            'class' => 'flex w-full items-center gap-3 rounded-xl px-4 py-2 text-sm font-medium text-slate-600 transition-colors duration-150 hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/70',
         ])
     }}
 >

--- a/resources/views/components/dropdown.blade.php
+++ b/resources/views/components/dropdown.blade.php
@@ -1,33 +1,42 @@
-@props(['align' => 'right', 'width' => '48', 'contentClasses' => 'bg-white/95 p-2 backdrop-blur'])
+@props(['align' => 'right', 'width' => '56', 'contentClasses' => 'p-2'])
 
 @php
-$alignmentClasses = match ($align) {
-    'left' => 'ltr:origin-top-left rtl:origin-top-right start-0',
-    'top' => 'origin-top',
-    default => 'ltr:origin-top-right rtl:origin-top-left end-0',
-};
+    $alignmentClasses = match ($align) {
+        'left' => 'ltr:origin-top-left rtl:origin-top-right start-0',
+        'top' => 'origin-top',
+        default => 'ltr:origin-top-right rtl:origin-top-left end-0',
+    };
 
-$width = match ($width) {
-    '48' => 'w-48',
-    default => $width,
-};
+    $width = match ($width) {
+        '48' => 'w-48',
+        '56' => 'w-56',
+        default => $width,
+    };
 @endphp
 
-<div class="relative" x-data="{ open: false }" @click.outside="open = false" @keydown.escape.window="open = false" @close.stop="open = false">
+<div
+    class="relative"
+    x-data="{ open: false }"
+    @click.outside="open = false"
+    @keydown.escape.window="open = false"
+    @close.stop="open = false"
+>
     <div @click="open = ! open">
         {{ $trigger }}
     </div>
 
-    <div x-show="open"
-            x-transition:enter="transition ease-out duration-150"
-            x-transition:enter-start="opacity-0 scale-95"
-            x-transition:enter-end="opacity-100 scale-100"
-            x-transition:leave="transition ease-in duration-100"
-            x-transition:leave-start="opacity-100 scale-100"
-            x-transition:leave-end="opacity-0 scale-95"
-            class="absolute z-50 mt-2 {{ $width }} rounded-2xl border border-slate-200 bg-white/80 shadow-xl backdrop-blur {{ $alignmentClasses }}"
-            style="display: none;"
-            @click="open = false">
+    <div
+        x-show="open"
+        x-transition:enter="transition ease-out duration-150"
+        x-transition:enter-start="opacity-0 scale-95"
+        x-transition:enter-end="opacity-100 scale-100"
+        x-transition:leave="transition ease-in duration-100"
+        x-transition:leave-start="opacity-100 scale-100"
+        x-transition:leave-end="opacity-0 scale-95"
+        class="absolute z-50 mt-3 {{ $width }} rounded-2xl border border-slate-200 bg-white/95 shadow-xl backdrop-blur {{ $alignmentClasses }}"
+        style="display: none;"
+        @click="open = false"
+    >
         <div class="rounded-2xl {{ $contentClasses }}">
             {{ $content }}
         </div>

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -5,23 +5,21 @@
 ])
 
 @php
-$maxWidth = [
-    'sm' => 'sm:max-w-sm',
-    'md' => 'sm:max-w-md',
-    'lg' => 'sm:max-w-lg',
-    'xl' => 'sm:max-w-xl',
-    '2xl' => 'sm:max-w-2xl',
-][$maxWidth];
+    $maxWidth = [
+        'sm' => 'sm:max-w-sm',
+        'md' => 'sm:max-w-md',
+        'lg' => 'sm:max-w-lg',
+        'xl' => 'sm:max-w-xl',
+        '2xl' => 'sm:max-w-2xl',
+    ][$maxWidth];
 @endphp
 
 <div
     x-data="{
         show: @js($show),
         focusables() {
-            // All focusable element types...
             let selector = 'a, button, input:not([type=\'hidden\']), textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'
             return [...$el.querySelectorAll(selector)]
-                // All non-disabled elements...
                 .filter(el => ! el.hasAttribute('disabled'))
         },
         firstFocusable() { return this.focusables()[0] },
@@ -46,12 +44,12 @@ $maxWidth = [
     x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"
     x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
     x-show="show"
-    class="fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50"
+    class="fixed inset-0 z-50 overflow-y-auto px-4 py-6 sm:px-0"
     style="display: {{ $show ? 'block' : 'none' }};"
 >
     <div
         x-show="show"
-        class="fixed inset-0 transform transition-all"
+        class="fixed inset-0 bg-slate-900/60 backdrop-blur-sm transition-opacity"
         x-on:click="show = false"
         x-transition:enter="ease-out duration-300"
         x-transition:enter-start="opacity-0"
@@ -59,13 +57,11 @@ $maxWidth = [
         x-transition:leave="ease-in duration-200"
         x-transition:leave-start="opacity-100"
         x-transition:leave-end="opacity-0"
-    >
-        <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
-    </div>
+    ></div>
 
     <div
         x-show="show"
-        class="mb-6 bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
+        class="relative mx-auto w-full transform overflow-hidden rounded-2xl border border-slate-100 bg-white shadow-2xl transition-all {{ $maxWidth }} sm:mx-auto"
         x-transition:enter="ease-out duration-300"
         x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
         x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"

--- a/resources/views/components/nav-link.blade.php
+++ b/resources/views/components/nav-link.blade.php
@@ -1,11 +1,13 @@
-@props(['active'])
+@props(['active' => false])
 
 @php
-$classes = ($active ?? false)
-            ? 'group flex items-center gap-3 rounded-lg bg-slate-800 px-3 py-2 text-sm font-semibold text-white shadow-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400'
-            : 'group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-slate-200 transition-colors duration-150 hover:bg-slate-800 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400';
+    $baseClasses = 'group flex items-center gap-3 rounded-xl px-4 py-2 text-sm transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/70 focus-visible:ring-offset-2';
+
+    $classes = $active
+        ? 'bg-indigo-600 text-white shadow-lg'
+        : 'text-slate-500 hover:bg-slate-100 hover:text-slate-900';
 @endphp
 
-<a {{ $attributes->merge(['class' => $classes]) }}>
+<a {{ $attributes->merge(['class' => trim($baseClasses . ' ' . $classes)]) }}>
     {{ $slot }}
 </a>

--- a/resources/views/components/primary-button.blade.php
+++ b/resources/views/components/primary-button.blade.php
@@ -1,3 +1,10 @@
-<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150']) }}>
+<button
+    {{
+        $attributes->merge([
+            'type' => 'submit',
+            'class' => 'inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition-colors duration-150 hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/70 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60',
+        ])
+    }}
+>
     {{ $slot }}
 </button>

--- a/resources/views/components/responsive-nav-link.blade.php
+++ b/resources/views/components/responsive-nav-link.blade.php
@@ -1,11 +1,13 @@
-@props(['active'])
+@props(['active' => false])
 
 @php
-$classes = ($active ?? false)
-            ? 'flex w-full items-center gap-3 rounded-xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400'
-            : 'flex w-full items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium text-slate-600 transition-colors duration-150 hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400';
+    $baseClasses = 'flex w-full items-center gap-3 rounded-xl px-4 py-3 text-sm transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/70';
+
+    $classes = $active
+        ? 'bg-indigo-600 text-white shadow-md'
+        : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900';
 @endphp
 
-<a {{ $attributes->merge(['class' => $classes]) }}>
+<a {{ $attributes->merge(['class' => trim($baseClasses . ' ' . $classes)]) }}>
     {{ $slot }}
 </a>

--- a/resources/views/components/secondary-button.blade.php
+++ b/resources/views/components/secondary-button.blade.php
@@ -1,3 +1,10 @@
-<button {{ $attributes->merge(['type' => 'button', 'class' => 'inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-25 transition ease-in-out duration-150']) }}>
+<button
+    {{
+        $attributes->merge([
+            'type' => 'button',
+            'class' => 'inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-5 py-2 text-sm font-semibold text-slate-600 shadow-sm transition-colors duration-150 hover:border-indigo-400 hover:text-indigo-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/70 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60',
+        ])
+    }}
+>
     {{ $slot }}
 </button>


### PR DESCRIPTION
## Summary
- refresh stat card and status table components to use TailAdmin-inspired layouts with icon and badge support plus zebra tables
- restyle navigation, dropdown, modal, and button components to keep spacing, focus and hover states consistent with the dashboard theme

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68de3c76b6a88321a3b943132c850050