### PR TITLE
Integrate TailAdmin frontend assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,21 @@
 {
-    "name": "sistema_bdys",
+    "name": "sistema-bdys",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "@alpinejs/persist": "^3.14.1",
+                "@fullcalendar/core": "^6.1.15",
+                "@fullcalendar/daygrid": "^6.1.15",
+                "@fullcalendar/interaction": "^6.1.15",
+                "@fullcalendar/list": "^6.1.15",
+                "@fullcalendar/timegrid": "^6.1.15",
+                "apexcharts": "^3.51.0",
+                "dropzone": "^6.0.0-beta.2",
+                "flatpickr": "^4.6.13",
+                "jsvectormap": "^1.6.0"
+            },
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.2",
                 "@tailwindcss/vite": "^4.0.0",
@@ -29,6 +41,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/@alpinejs/persist": {
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.15.0.tgz",
+            "integrity": "sha512-SmW1DWn9FRflfPqZZtpTq+2uXDq/ohbSiKmYg6HXX1UxQnsaSkTT0HT72SQcbqOC3WmIUF28CberBnwiWoqmpw==",
+            "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.9",
@@ -470,6 +488,54 @@
             ],
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@fullcalendar/core": {
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.19.tgz",
+            "integrity": "sha512-z0aVlO5e4Wah6p6mouM0UEqtRf1MZZPt4mwzEyU6kusaNL+dlWQgAasF2cK23hwT4cmxkEmr4inULXgpyeExdQ==",
+            "license": "MIT",
+            "dependencies": {
+                "preact": "~10.12.1"
+            }
+        },
+        "node_modules/@fullcalendar/daygrid": {
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.19.tgz",
+            "integrity": "sha512-IAAfnMICnVWPjpT4zi87i3FEw0xxSza0avqY/HedKEz+l5MTBYvCDPOWDATpzXoLut3aACsjktIyw9thvIcRYQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@fullcalendar/core": "~6.1.19"
+            }
+        },
+        "node_modules/@fullcalendar/interaction": {
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.19.tgz",
+            "integrity": "sha512-GOciy79xe8JMVp+1evAU3ytdwN/7tv35t5i1vFkifiuWcQMLC/JnLg/RA2s4sYmQwoYhTw/p4GLcP0gO5B3X5w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@fullcalendar/core": "~6.1.19"
+            }
+        },
+        "node_modules/@fullcalendar/list": {
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-6.1.19.tgz",
+            "integrity": "sha512-knZHpAVF0LbzZpSJSUmLUUzF0XlU/MRGK+Py2s0/mP93bCtno1k2L3XPs/kzh528hSjehwLm89RgKTSfW1P6cA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@fullcalendar/core": "~6.1.19"
+            }
+        },
+        "node_modules/@fullcalendar/timegrid": {
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.19.tgz",
+            "integrity": "sha512-OuzpUueyO9wB5OZ8rs7TWIoqvu4v3yEqdDxZ2VcsMldCpYJRiOe7yHWKr4ap5Tb0fs7Rjbserc/b6Nt7ol6BRg==",
+            "license": "MIT",
+            "dependencies": {
+                "@fullcalendar/daygrid": "~6.1.19"
+            },
+            "peerDependencies": {
+                "@fullcalendar/core": "~6.1.19"
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -967,6 +1033,12 @@
                 "win32"
             ]
         },
+        "node_modules/@swc/helpers": {
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.2.14.tgz",
+            "integrity": "sha512-wpCQMhf5p5GhNg2MmGKXzUNwxe7zRiCsmqYsamez2beP7mKPCSiu+BjZcdN95yYSzO857kr0VfQewmGpS77nqA==",
+            "license": "MIT"
+        },
         "node_modules/@tailwindcss/forms": {
             "version": "0.5.10",
             "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.10.tgz",
@@ -1295,6 +1367,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@yr/monotone-cubic-spline": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
+            "integrity": "sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA==",
+            "license": "MIT"
+        },
         "node_modules/alpinejs": {
             "version": "3.14.9",
             "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.14.9.tgz",
@@ -1363,6 +1441,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/apexcharts": {
+            "version": "3.54.1",
+            "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.54.1.tgz",
+            "integrity": "sha512-E4et0h/J1U3r3EwS/WlqJCQIbepKbp6wGUmaAwJOMjHUP4Ci0gxanLa7FR3okx6p9coi4st6J853/Cb1NP0vpA==",
+            "license": "MIT",
+            "dependencies": {
+                "@yr/monotone-cubic-spline": "^1.0.3",
+                "svg.draggable.js": "^2.2.2",
+                "svg.easing.js": "^2.0.0",
+                "svg.filter.js": "^2.0.2",
+                "svg.pathmorphing.js": "^0.1.3",
+                "svg.resize.js": "^1.4.3",
+                "svg.select.js": "^3.0.1"
             }
         },
         "node_modules/arg": {
@@ -1774,6 +1867,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/dropzone": {
+            "version": "6.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-6.0.0-beta.2.tgz",
+            "integrity": "sha512-k44yLuFFhRk53M8zP71FaaNzJYIzr99SKmpbO/oZKNslDjNXQsBTdfLs+iONd0U0L94zzlFzRnFdqbLcs7h9fQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@swc/helpers": "^0.2.13",
+                "just-extend": "^5.0.0"
+            }
+        },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1995,6 +2098,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/flatpickr": {
+            "version": "4.6.13",
+            "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
+            "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==",
+            "license": "MIT"
         },
         "node_modules/follow-redirects": {
             "version": "1.15.11",
@@ -2349,6 +2458,18 @@
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
+        },
+        "node_modules/jsvectormap": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/jsvectormap/-/jsvectormap-1.7.0.tgz",
+            "integrity": "sha512-8VmL3Uuen08Es9xb2N6Wdc32TrQDGPXYCIdTB126jAhTJsYd/4r4Mc63VQA3qHxG0p4zeCI8sFO5XRsdjljMJg==",
+            "license": "MIT"
+        },
+        "node_modules/just-extend": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-5.1.1.tgz",
+            "integrity": "sha512-b+z6yF1d4EOyDgylzQo5IminlUmzSeqR1hs/bzjBNjuGras4FXq/6TrzjxfN0j+TmI0ltJzTNlqXUMCniciwKQ==",
+            "license": "MIT"
         },
         "node_modules/laravel-vite-plugin": {
             "version": "2.0.0",
@@ -3097,6 +3218,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/preact": {
+            "version": "10.12.1",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+            "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/preact"
+            }
+        },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3444,6 +3575,97 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/svg.draggable.js": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/svg.draggable.js/-/svg.draggable.js-2.2.2.tgz",
+            "integrity": "sha512-JzNHBc2fLQMzYCZ90KZHN2ohXL0BQJGQimK1kGk6AvSeibuKcIdDX9Kr0dT9+UJ5O8nYA0RB839Lhvk4CY4MZw==",
+            "license": "MIT",
+            "dependencies": {
+                "svg.js": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/svg.easing.js": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/svg.easing.js/-/svg.easing.js-2.0.0.tgz",
+            "integrity": "sha512-//ctPdJMGy22YoYGV+3HEfHbm6/69LJUTAqI2/5qBvaNHZ9uUFVC82B0Pl299HzgH13rKrBgi4+XyXXyVWWthA==",
+            "license": "MIT",
+            "dependencies": {
+                "svg.js": ">=2.3.x"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/svg.filter.js": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/svg.filter.js/-/svg.filter.js-2.0.2.tgz",
+            "integrity": "sha512-xkGBwU+dKBzqg5PtilaTb0EYPqPfJ9Q6saVldX+5vCRy31P6TlRCP3U9NxH3HEufkKkpNgdTLBJnmhDHeTqAkw==",
+            "license": "MIT",
+            "dependencies": {
+                "svg.js": "^2.2.5"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/svg.js": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/svg.js/-/svg.js-2.7.1.tgz",
+            "integrity": "sha512-ycbxpizEQktk3FYvn/8BH+6/EuWXg7ZpQREJvgacqn46gIddG24tNNe4Son6omdXCnSOaApnpZw6MPCBA1dODA==",
+            "license": "MIT"
+        },
+        "node_modules/svg.pathmorphing.js": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/svg.pathmorphing.js/-/svg.pathmorphing.js-0.1.3.tgz",
+            "integrity": "sha512-49HWI9X4XQR/JG1qXkSDV8xViuTLIWm/B/7YuQELV5KMOPtXjiwH4XPJvr/ghEDibmLQ9Oc22dpWpG0vUDDNww==",
+            "license": "MIT",
+            "dependencies": {
+                "svg.js": "^2.4.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/svg.resize.js": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/svg.resize.js/-/svg.resize.js-1.4.3.tgz",
+            "integrity": "sha512-9k5sXJuPKp+mVzXNvxz7U0uC9oVMQrrf7cFsETznzUDDm0x8+77dtZkWdMfRlmbkEEYvUn9btKuZ3n41oNA+uw==",
+            "license": "MIT",
+            "dependencies": {
+                "svg.js": "^2.6.5",
+                "svg.select.js": "^2.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/svg.resize.js/node_modules/svg.select.js": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-2.1.2.tgz",
+            "integrity": "sha512-tH6ABEyJsAOVAhwcCjF8mw4crjXSI1aa7j2VQR8ZuJ37H2MBUbyeqYr5nEO7sSN3cy9AR9DUwNg0t/962HlDbQ==",
+            "license": "MIT",
+            "dependencies": {
+                "svg.js": "^2.2.5"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/svg.select.js": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-3.0.1.tgz",
+            "integrity": "sha512-h5IS/hKkuVCbKSieR9uQCj9w+zLHoPh+ce19bBYyqF53g6mnPB8sAtIbe1s9dh2S2fCmYX2xel1Ln3PJBbK4kw==",
+            "license": "MIT",
+            "dependencies": {
+                "svg.js": "^2.6.5"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
         "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -17,5 +17,17 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
         "vite": "^7.0.4"
+    },
+    "dependencies": {
+        "@alpinejs/persist": "^3.14.1",
+        "@fullcalendar/core": "^6.1.15",
+        "@fullcalendar/daygrid": "^6.1.15",
+        "@fullcalendar/interaction": "^6.1.15",
+        "@fullcalendar/list": "^6.1.15",
+        "@fullcalendar/timegrid": "^6.1.15",
+        "apexcharts": "^3.51.0",
+        "dropzone": "^6.0.0-beta.2",
+        "flatpickr": "^4.6.13",
+        "jsvectormap": "^1.6.0"
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,5 @@
+@import './tailadmin.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/resources/css/tailadmin.css
+++ b/resources/css/tailadmin.css
@@ -1,0 +1,4807 @@
+/*!********************************************************************************************************************************************************!*\
+  !*** css ./node_modules/css-loader/dist/cjs.js!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./src/css/style.css (layer base) ***!
+  \********************************************************************************************************************************************************/
+@import url(https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap) layer(base);
+/*!***************************************************************************************************************************************************************************!*\
+  !*** css ./node_modules/css-loader/dist/cjs.js!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./node_modules/jsvectormap/dist/jsvectormap.min.css ***!
+  \***************************************************************************************************************************************************************************/
+svg{-ms-touch-action:none;touch-action:none}image,text,.jvm-zoomin,.jvm-zoomout{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.jvm-container{-ms-touch-action:none;touch-action:none;position:relative;overflow:hidden;height:100%;width:100%}.jvm-tooltip{border-radius:3px;background-color:#5c5cff;font-family:sans-serif,Verdana;font-size:smaller;-webkit-box-shadow:1px 2px 12px rgba(0,0,0,.2);box-shadow:1px 2px 12px rgba(0,0,0,.2);padding:3px 5px;white-space:nowrap;position:absolute;display:none;color:#fff}.jvm-tooltip.active{display:block}.jvm-zoom-btn{border-radius:3px;background-color:#292929;padding:3px;-webkit-box-sizing:border-box;box-sizing:border-box;position:absolute;line-height:10px;cursor:pointer;color:#fff;height:15px;width:15px;left:10px}.jvm-zoom-btn.jvm-zoomout{top:30px}.jvm-zoom-btn.jvm-zoomin{top:10px}.jvm-series-container{right:15px;position:absolute}.jvm-series-container.jvm-series-h{bottom:15px}.jvm-series-container.jvm-series-v{top:15px}.jvm-series-container .jvm-legend{background-color:#fff;border:1px solid #e5e7eb;margin-left:.75rem;border-radius:.25rem;border-color:#e5e7eb;padding:.6rem;-webkit-box-shadow:0 1px 2px 0 rgba(0,0,0,.05);box-shadow:0 1px 2px 0 rgba(0,0,0,.05);float:left}.jvm-series-container .jvm-legend .jvm-legend-title{line-height:1;border-bottom:1px solid #e5e7eb;padding-bottom:.5rem;margin-bottom:.575rem;text-align:left}.jvm-series-container .jvm-legend .jvm-legend-inner{overflow:hidden}.jvm-series-container .jvm-legend .jvm-legend-inner .jvm-legend-tick{overflow:hidden;min-width:40px}.jvm-series-container .jvm-legend .jvm-legend-inner .jvm-legend-tick:not(:first-child){margin-top:.575rem}.jvm-series-container .jvm-legend .jvm-legend-inner .jvm-legend-tick .jvm-legend-tick-sample{border-radius:4px;margin-right:.65rem;height:16px;width:16px;float:left}.jvm-series-container .jvm-legend .jvm-legend-inner .jvm-legend-tick .jvm-legend-tick-text{font-size:12px;text-align:center;float:left}.jvm-line[animation=true]{-webkit-animation:jvm-line-animation 10s linear forwards infinite;animation:jvm-line-animation 10s linear forwards infinite}@-webkit-keyframes jvm-line-animation{from{stroke-dashoffset:250}}@keyframes jvm-line-animation{from{stroke-dashoffset:250}}
+/*!***********************************************************************************************************************************************************************!*\
+  !*** css ./node_modules/css-loader/dist/cjs.js!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./node_modules/flatpickr/dist/flatpickr.min.css ***!
+  \***********************************************************************************************************************************************************************/
+.flatpickr-calendar{background:transparent;opacity:0;display:none;text-align:center;visibility:hidden;padding:0;-webkit-animation:none;animation:none;direction:ltr;border:0;font-size:14px;line-height:24px;border-radius:5px;position:absolute;width:307.875px;-webkit-box-sizing:border-box;box-sizing:border-box;-ms-touch-action:manipulation;touch-action:manipulation;background:#fff;-webkit-box-shadow:1px 0 0 #e6e6e6,-1px 0 0 #e6e6e6,0 1px 0 #e6e6e6,0 -1px 0 #e6e6e6,0 3px 13px rgba(0,0,0,0.08);box-shadow:1px 0 0 #e6e6e6,-1px 0 0 #e6e6e6,0 1px 0 #e6e6e6,0 -1px 0 #e6e6e6,0 3px 13px rgba(0,0,0,0.08)}.flatpickr-calendar.open,.flatpickr-calendar.inline{opacity:1;max-height:640px;visibility:visible}.flatpickr-calendar.open{display:inline-block;z-index:99999}.flatpickr-calendar.animate.open{-webkit-animation:fpFadeInDown 300ms cubic-bezier(.23,1,.32,1);animation:fpFadeInDown 300ms cubic-bezier(.23,1,.32,1)}.flatpickr-calendar.inline{display:block;position:relative;top:2px}.flatpickr-calendar.static{position:absolute;top:calc(100% + 2px)}.flatpickr-calendar.static.open{z-index:999;display:block}.flatpickr-calendar.multiMonth .flatpickr-days .dayContainer:nth-child(n+1) .flatpickr-day.inRange:nth-child(7n+7){-webkit-box-shadow:none !important;box-shadow:none !important}.flatpickr-calendar.multiMonth .flatpickr-days .dayContainer:nth-child(n+2) .flatpickr-day.inRange:nth-child(7n+1){-webkit-box-shadow:-2px 0 0 #e6e6e6,5px 0 0 #e6e6e6;box-shadow:-2px 0 0 #e6e6e6,5px 0 0 #e6e6e6}.flatpickr-calendar .hasWeeks .dayContainer,.flatpickr-calendar .hasTime .dayContainer{border-bottom:0;border-bottom-right-radius:0;border-bottom-left-radius:0}.flatpickr-calendar .hasWeeks .dayContainer{border-left:0}.flatpickr-calendar.hasTime .flatpickr-time{height:40px;border-top:1px solid #e6e6e6}.flatpickr-calendar.noCalendar.hasTime .flatpickr-time{height:auto}.flatpickr-calendar:before,.flatpickr-calendar:after{position:absolute;display:block;pointer-events:none;border:solid transparent;content:'';height:0;width:0;left:22px}.flatpickr-calendar.rightMost:before,.flatpickr-calendar.arrowRight:before,.flatpickr-calendar.rightMost:after,.flatpickr-calendar.arrowRight:after{left:auto;right:22px}.flatpickr-calendar.arrowCenter:before,.flatpickr-calendar.arrowCenter:after{left:50%;right:50%}.flatpickr-calendar:before{border-width:5px;margin:0 -5px}.flatpickr-calendar:after{border-width:4px;margin:0 -4px}.flatpickr-calendar.arrowTop:before,.flatpickr-calendar.arrowTop:after{bottom:100%}.flatpickr-calendar.arrowTop:before{border-bottom-color:#e6e6e6}.flatpickr-calendar.arrowTop:after{border-bottom-color:#fff}.flatpickr-calendar.arrowBottom:before,.flatpickr-calendar.arrowBottom:after{top:100%}.flatpickr-calendar.arrowBottom:before{border-top-color:#e6e6e6}.flatpickr-calendar.arrowBottom:after{border-top-color:#fff}.flatpickr-calendar:focus{outline:0}.flatpickr-wrapper{position:relative;display:inline-block}.flatpickr-months{display:-webkit-box;display:-ms-flexbox;display:flex}.flatpickr-months .flatpickr-month{background:transparent;color:rgba(0,0,0,0.9);fill:rgba(0,0,0,0.9);height:34px;line-height:1;text-align:center;position:relative;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;overflow:hidden;-webkit-box-flex:1;-ms-flex:1;flex:1}.flatpickr-months .flatpickr-prev-month,.flatpickr-months .flatpickr-next-month{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;text-decoration:none;cursor:pointer;position:absolute;top:0;height:34px;padding:10px;z-index:3;color:rgba(0,0,0,0.9);fill:rgba(0,0,0,0.9)}.flatpickr-months .flatpickr-prev-month.flatpickr-disabled,.flatpickr-months .flatpickr-next-month.flatpickr-disabled{display:none}.flatpickr-months .flatpickr-prev-month i,.flatpickr-months .flatpickr-next-month i{position:relative}.flatpickr-months .flatpickr-prev-month.flatpickr-prev-month,.flatpickr-months .flatpickr-next-month.flatpickr-prev-month{/*
+      /*rtl:begin:ignore*/left:0/*
+      /*rtl:end:ignore*/}/*
+      /*rtl:begin:ignore*/
+/*
+      /*rtl:end:ignore*/
+.flatpickr-months .flatpickr-prev-month.flatpickr-next-month,.flatpickr-months .flatpickr-next-month.flatpickr-next-month{/*
+      /*rtl:begin:ignore*/right:0/*
+      /*rtl:end:ignore*/}/*
+      /*rtl:begin:ignore*/
+/*
+      /*rtl:end:ignore*/
+.flatpickr-months .flatpickr-prev-month:hover,.flatpickr-months .flatpickr-next-month:hover{color:#959ea9}.flatpickr-months .flatpickr-prev-month:hover svg,.flatpickr-months .flatpickr-next-month:hover svg{fill:#f64747}.flatpickr-months .flatpickr-prev-month svg,.flatpickr-months .flatpickr-next-month svg{width:14px;height:14px}.flatpickr-months .flatpickr-prev-month svg path,.flatpickr-months .flatpickr-next-month svg path{-webkit-transition:fill .1s;transition:fill .1s;fill:inherit}.numInputWrapper{position:relative;height:auto}.numInputWrapper input,.numInputWrapper span{display:inline-block}.numInputWrapper input{width:100%}.numInputWrapper input::-ms-clear{display:none}.numInputWrapper input::-webkit-outer-spin-button,.numInputWrapper input::-webkit-inner-spin-button{margin:0;-webkit-appearance:none}.numInputWrapper span{position:absolute;right:0;width:14px;padding:0 4px 0 2px;height:50%;line-height:50%;opacity:0;cursor:pointer;border:1px solid rgba(57,57,57,0.15);-webkit-box-sizing:border-box;box-sizing:border-box}.numInputWrapper span:hover{background:rgba(0,0,0,0.1)}.numInputWrapper span:active{background:rgba(0,0,0,0.2)}.numInputWrapper span:after{display:block;content:"";position:absolute}.numInputWrapper span.arrowUp{top:0;border-bottom:0}.numInputWrapper span.arrowUp:after{border-left:4px solid transparent;border-right:4px solid transparent;border-bottom:4px solid rgba(57,57,57,0.6);top:26%}.numInputWrapper span.arrowDown{top:50%}.numInputWrapper span.arrowDown:after{border-left:4px solid transparent;border-right:4px solid transparent;border-top:4px solid rgba(57,57,57,0.6);top:40%}.numInputWrapper span svg{width:inherit;height:auto}.numInputWrapper span svg path{fill:rgba(0,0,0,0.5)}.numInputWrapper:hover{background:rgba(0,0,0,0.05)}.numInputWrapper:hover span{opacity:1}.flatpickr-current-month{font-size:135%;line-height:inherit;font-weight:300;color:inherit;position:absolute;width:75%;left:12.5%;padding:7.48px 0 0 0;line-height:1;height:34px;display:inline-block;text-align:center;-webkit-transform:translate3d(0,0,0);transform:translate3d(0,0,0)}.flatpickr-current-month span.cur-month{font-family:inherit;font-weight:700;color:inherit;display:inline-block;margin-left:.5ch;padding:0}.flatpickr-current-month span.cur-month:hover{background:rgba(0,0,0,0.05)}.flatpickr-current-month .numInputWrapper{width:6ch;width:7ch\0;display:inline-block}.flatpickr-current-month .numInputWrapper span.arrowUp:after{border-bottom-color:rgba(0,0,0,0.9)}.flatpickr-current-month .numInputWrapper span.arrowDown:after{border-top-color:rgba(0,0,0,0.9)}.flatpickr-current-month input.cur-year{background:transparent;-webkit-box-sizing:border-box;box-sizing:border-box;color:inherit;cursor:text;padding:0 0 0 .5ch;margin:0;display:inline-block;font-size:inherit;font-family:inherit;font-weight:300;line-height:inherit;height:auto;border:0;border-radius:0;vertical-align:initial;-webkit-appearance:textfield;-moz-appearance:textfield;appearance:textfield}.flatpickr-current-month input.cur-year:focus{outline:0}.flatpickr-current-month input.cur-year[disabled],.flatpickr-current-month input.cur-year[disabled]:hover{font-size:100%;color:rgba(0,0,0,0.5);background:transparent;pointer-events:none}.flatpickr-current-month .flatpickr-monthDropdown-months{appearance:menulist;background:transparent;border:none;border-radius:0;box-sizing:border-box;color:inherit;cursor:pointer;font-size:inherit;font-family:inherit;font-weight:300;height:auto;line-height:inherit;margin:-1px 0 0 0;outline:none;padding:0 0 0 .5ch;position:relative;vertical-align:initial;-webkit-box-sizing:border-box;-webkit-appearance:menulist;-moz-appearance:menulist;width:auto}.flatpickr-current-month .flatpickr-monthDropdown-months:focus,.flatpickr-current-month .flatpickr-monthDropdown-months:active{outline:none}.flatpickr-current-month .flatpickr-monthDropdown-months:hover{background:rgba(0,0,0,0.05)}.flatpickr-current-month .flatpickr-monthDropdown-months .flatpickr-monthDropdown-month{background-color:transparent;outline:none;padding:0}.flatpickr-weekdays{background:transparent;text-align:center;overflow:hidden;width:100%;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-align:center;-ms-flex-align:center;align-items:center;height:28px}.flatpickr-weekdays .flatpickr-weekdaycontainer{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-flex:1;-ms-flex:1;flex:1}span.flatpickr-weekday{cursor:default;font-size:90%;background:transparent;color:rgba(0,0,0,0.54);line-height:1;margin:0;text-align:center;display:block;-webkit-box-flex:1;-ms-flex:1;flex:1;font-weight:bolder}.dayContainer,.flatpickr-weeks{padding:1px 0 0 0}.flatpickr-days{position:relative;overflow:hidden;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-align:start;-ms-flex-align:start;align-items:flex-start;width:307.875px}.flatpickr-days:focus{outline:0}.dayContainer{padding:0;outline:0;text-align:left;width:307.875px;min-width:307.875px;max-width:307.875px;-webkit-box-sizing:border-box;box-sizing:border-box;display:inline-block;display:-ms-flexbox;display:-webkit-box;display:flex;flex-wrap:wrap;-ms-flex-wrap:wrap;-ms-flex-pack:justify;justify-content:space-around;-webkit-transform:translate3d(0,0,0);transform:translate3d(0,0,0);opacity:1}.dayContainer + .dayContainer{-webkit-box-shadow:-1px 0 0 #e6e6e6;box-shadow:-1px 0 0 #e6e6e6}.flatpickr-day{background:none;border:1px solid transparent;border-radius:150px;-webkit-box-sizing:border-box;box-sizing:border-box;color:#393939;cursor:pointer;font-weight:400;width:14.2857143%;-ms-flex-preferred-size:14.2857143%;flex-basis:14.2857143%;max-width:39px;height:39px;line-height:39px;margin:0;display:inline-block;position:relative;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;text-align:center}.flatpickr-day.inRange,.flatpickr-day.prevMonthDay.inRange,.flatpickr-day.nextMonthDay.inRange,.flatpickr-day.today.inRange,.flatpickr-day.prevMonthDay.today.inRange,.flatpickr-day.nextMonthDay.today.inRange,.flatpickr-day:hover,.flatpickr-day.prevMonthDay:hover,.flatpickr-day.nextMonthDay:hover,.flatpickr-day:focus,.flatpickr-day.prevMonthDay:focus,.flatpickr-day.nextMonthDay:focus{cursor:pointer;outline:0;background:#e6e6e6;border-color:#e6e6e6}.flatpickr-day.today{border-color:#959ea9}.flatpickr-day.today:hover,.flatpickr-day.today:focus{border-color:#959ea9;background:#959ea9;color:#fff}.flatpickr-day.selected,.flatpickr-day.startRange,.flatpickr-day.endRange,.flatpickr-day.selected.inRange,.flatpickr-day.startRange.inRange,.flatpickr-day.endRange.inRange,.flatpickr-day.selected:focus,.flatpickr-day.startRange:focus,.flatpickr-day.endRange:focus,.flatpickr-day.selected:hover,.flatpickr-day.startRange:hover,.flatpickr-day.endRange:hover,.flatpickr-day.selected.prevMonthDay,.flatpickr-day.startRange.prevMonthDay,.flatpickr-day.endRange.prevMonthDay,.flatpickr-day.selected.nextMonthDay,.flatpickr-day.startRange.nextMonthDay,.flatpickr-day.endRange.nextMonthDay{background:#569ff7;-webkit-box-shadow:none;box-shadow:none;color:#fff;border-color:#569ff7}.flatpickr-day.selected.startRange,.flatpickr-day.startRange.startRange,.flatpickr-day.endRange.startRange{border-radius:50px 0 0 50px}.flatpickr-day.selected.endRange,.flatpickr-day.startRange.endRange,.flatpickr-day.endRange.endRange{border-radius:0 50px 50px 0}.flatpickr-day.selected.startRange + .endRange:not(:nth-child(7n+1)),.flatpickr-day.startRange.startRange + .endRange:not(:nth-child(7n+1)),.flatpickr-day.endRange.startRange + .endRange:not(:nth-child(7n+1)){-webkit-box-shadow:-10px 0 0 #569ff7;box-shadow:-10px 0 0 #569ff7}.flatpickr-day.selected.startRange.endRange,.flatpickr-day.startRange.startRange.endRange,.flatpickr-day.endRange.startRange.endRange{border-radius:50px}.flatpickr-day.inRange{border-radius:0;-webkit-box-shadow:-5px 0 0 #e6e6e6,5px 0 0 #e6e6e6;box-shadow:-5px 0 0 #e6e6e6,5px 0 0 #e6e6e6}.flatpickr-day.flatpickr-disabled,.flatpickr-day.flatpickr-disabled:hover,.flatpickr-day.prevMonthDay,.flatpickr-day.nextMonthDay,.flatpickr-day.notAllowed,.flatpickr-day.notAllowed.prevMonthDay,.flatpickr-day.notAllowed.nextMonthDay{color:rgba(57,57,57,0.3);background:transparent;border-color:transparent;cursor:default}.flatpickr-day.flatpickr-disabled,.flatpickr-day.flatpickr-disabled:hover{cursor:not-allowed;color:rgba(57,57,57,0.1)}.flatpickr-day.week.selected{border-radius:0;-webkit-box-shadow:-5px 0 0 #569ff7,5px 0 0 #569ff7;box-shadow:-5px 0 0 #569ff7,5px 0 0 #569ff7}.flatpickr-day.hidden{visibility:hidden}.rangeMode .flatpickr-day{margin-top:1px}.flatpickr-weekwrapper{float:left}.flatpickr-weekwrapper .flatpickr-weeks{padding:0 12px;-webkit-box-shadow:1px 0 0 #e6e6e6;box-shadow:1px 0 0 #e6e6e6}.flatpickr-weekwrapper .flatpickr-weekday{float:none;width:100%;line-height:28px}.flatpickr-weekwrapper span.flatpickr-day,.flatpickr-weekwrapper span.flatpickr-day:hover{display:block;width:100%;max-width:none;color:rgba(57,57,57,0.3);background:transparent;cursor:default;border:none}.flatpickr-innerContainer{display:block;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-sizing:border-box;box-sizing:border-box;overflow:hidden}.flatpickr-rContainer{display:inline-block;padding:0;-webkit-box-sizing:border-box;box-sizing:border-box}.flatpickr-time{text-align:center;outline:0;display:block;height:0;line-height:40px;max-height:40px;-webkit-box-sizing:border-box;box-sizing:border-box;overflow:hidden;display:-webkit-box;display:-ms-flexbox;display:flex}.flatpickr-time:after{content:"";display:table;clear:both}.flatpickr-time .numInputWrapper{-webkit-box-flex:1;-ms-flex:1;flex:1;width:40%;height:40px;float:left}.flatpickr-time .numInputWrapper span.arrowUp:after{border-bottom-color:#393939}.flatpickr-time .numInputWrapper span.arrowDown:after{border-top-color:#393939}.flatpickr-time.hasSeconds .numInputWrapper{width:26%}.flatpickr-time.time24hr .numInputWrapper{width:49%}.flatpickr-time input{background:transparent;-webkit-box-shadow:none;box-shadow:none;border:0;border-radius:0;text-align:center;margin:0;padding:0;height:inherit;line-height:inherit;color:#393939;font-size:14px;position:relative;-webkit-box-sizing:border-box;box-sizing:border-box;-webkit-appearance:textfield;-moz-appearance:textfield;appearance:textfield}.flatpickr-time input.flatpickr-hour{font-weight:bold}.flatpickr-time input.flatpickr-minute,.flatpickr-time input.flatpickr-second{font-weight:400}.flatpickr-time input:focus{outline:0;border:0}.flatpickr-time .flatpickr-time-separator,.flatpickr-time .flatpickr-am-pm{height:inherit;float:left;line-height:inherit;color:#393939;font-weight:bold;width:2%;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;-webkit-align-self:center;-ms-flex-item-align:center;align-self:center}.flatpickr-time .flatpickr-am-pm{outline:0;width:18%;cursor:pointer;text-align:center;font-weight:400}.flatpickr-time input:hover,.flatpickr-time .flatpickr-am-pm:hover,.flatpickr-time input:focus,.flatpickr-time .flatpickr-am-pm:focus{background:#eee}.flatpickr-input[readonly]{cursor:pointer}@-webkit-keyframes fpFadeInDown{from{opacity:0;-webkit-transform:translate3d(0,-20px,0);transform:translate3d(0,-20px,0)}to{opacity:1;-webkit-transform:translate3d(0,0,0);transform:translate3d(0,0,0)}}@keyframes fpFadeInDown{from{opacity:0;-webkit-transform:translate3d(0,-20px,0);transform:translate3d(0,-20px,0)}to{opacity:1;-webkit-transform:translate3d(0,0,0);transform:translate3d(0,0,0)}}
+/*!*****************************************************************************************************************************************************************!*\
+  !*** css ./node_modules/css-loader/dist/cjs.js!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./node_modules/dropzone/dist/dropzone.css ***!
+  \*****************************************************************************************************************************************************************/
+@-webkit-keyframes passing-through{0%{opacity:0;-webkit-transform:translateY(40px);transform:translateY(40px)}30%,70%{opacity:1;-webkit-transform:translateY(0px);transform:translateY(0px)}100%{opacity:0;-webkit-transform:translateY(-40px);transform:translateY(-40px)}}@keyframes passing-through{0%{opacity:0;-webkit-transform:translateY(40px);transform:translateY(40px)}30%,70%{opacity:1;-webkit-transform:translateY(0px);transform:translateY(0px)}100%{opacity:0;-webkit-transform:translateY(-40px);transform:translateY(-40px)}}@-webkit-keyframes slide-in{0%{opacity:0;-webkit-transform:translateY(40px);transform:translateY(40px)}30%{opacity:1;-webkit-transform:translateY(0px);transform:translateY(0px)}}@keyframes slide-in{0%{opacity:0;-webkit-transform:translateY(40px);transform:translateY(40px)}30%{opacity:1;-webkit-transform:translateY(0px);transform:translateY(0px)}}@-webkit-keyframes pulse{0%{-webkit-transform:scale(1);transform:scale(1)}10%{-webkit-transform:scale(1.1);transform:scale(1.1)}20%{-webkit-transform:scale(1);transform:scale(1)}}@keyframes pulse{0%{-webkit-transform:scale(1);transform:scale(1)}10%{-webkit-transform:scale(1.1);transform:scale(1.1)}20%{-webkit-transform:scale(1);transform:scale(1)}}.dropzone,.dropzone *{-webkit-box-sizing:border-box;box-sizing:border-box}.dropzone{min-height:150px;border:1px solid rgba(0,0,0,.8);border-radius:5px;padding:20px 20px}.dropzone.dz-clickable{cursor:pointer}.dropzone.dz-clickable *{cursor:default}.dropzone.dz-clickable .dz-message,.dropzone.dz-clickable .dz-message *{cursor:pointer}.dropzone.dz-started .dz-message{display:none}.dropzone.dz-drag-hover{border-style:solid}.dropzone.dz-drag-hover .dz-message{opacity:.5}.dropzone .dz-message{text-align:center;margin:3em 0}.dropzone .dz-message .dz-button{background:none;color:inherit;border:none;padding:0;font:inherit;cursor:pointer;outline:inherit}.dropzone .dz-preview{position:relative;display:inline-block;vertical-align:top;margin:16px;min-height:100px}.dropzone .dz-preview:hover{z-index:1000}.dropzone .dz-preview:hover .dz-details{opacity:1}.dropzone .dz-preview.dz-file-preview .dz-image{border-radius:20px;background:#999;background:-webkit-gradient(linear, left top, left bottom, from(#eee), to(#ddd));background:linear-gradient(to bottom, #eee, #ddd)}.dropzone .dz-preview.dz-file-preview .dz-details{opacity:1}.dropzone .dz-preview.dz-image-preview{background:#fff}.dropzone .dz-preview.dz-image-preview .dz-details{-webkit-transition:opacity .2s linear;transition:opacity .2s linear}.dropzone .dz-preview .dz-remove{font-size:14px;text-align:center;display:block;cursor:pointer;border:none}.dropzone .dz-preview .dz-remove:hover{text-decoration:underline}.dropzone .dz-preview:hover .dz-details{opacity:1}.dropzone .dz-preview .dz-details{z-index:20;position:absolute;top:0;left:0;opacity:0;font-size:13px;min-width:100%;max-width:100%;padding:2em 1em;text-align:center;color:rgba(0,0,0,.9);line-height:150%}.dropzone .dz-preview .dz-details .dz-size{margin-bottom:1em;font-size:16px}.dropzone .dz-preview .dz-details .dz-filename{white-space:nowrap}.dropzone .dz-preview .dz-details .dz-filename:hover span{border:1px solid rgba(200,200,200,.8);background-color:rgba(255,255,255,.8)}.dropzone .dz-preview .dz-details .dz-filename:not(:hover){overflow:hidden;text-overflow:ellipsis}.dropzone .dz-preview .dz-details .dz-filename:not(:hover) span{border:1px solid transparent}.dropzone .dz-preview .dz-details .dz-filename span,.dropzone .dz-preview .dz-details .dz-size span{background-color:rgba(255,255,255,.4);padding:0 .4em;border-radius:3px}.dropzone .dz-preview:hover .dz-image img{-webkit-transform:scale(1.05, 1.05);transform:scale(1.05, 1.05);-webkit-filter:blur(8px);filter:blur(8px)}.dropzone .dz-preview .dz-image{border-radius:20px;overflow:hidden;width:120px;height:120px;position:relative;display:block;z-index:10}.dropzone .dz-preview .dz-image img{display:block}.dropzone .dz-preview.dz-success .dz-success-mark{-webkit-animation:passing-through 3s cubic-bezier(0.77, 0, 0.175, 1);animation:passing-through 3s cubic-bezier(0.77, 0, 0.175, 1)}.dropzone .dz-preview.dz-error .dz-error-mark{opacity:1;-webkit-animation:slide-in 3s cubic-bezier(0.77, 0, 0.175, 1);animation:slide-in 3s cubic-bezier(0.77, 0, 0.175, 1)}.dropzone .dz-preview .dz-success-mark,.dropzone .dz-preview .dz-error-mark{pointer-events:none;opacity:0;z-index:500;position:absolute;display:block;top:50%;left:50%;margin-left:-27px;margin-top:-27px;background:rgba(0,0,0,.8);border-radius:50%}.dropzone .dz-preview .dz-success-mark svg,.dropzone .dz-preview .dz-error-mark svg{display:block;width:54px;height:54px;fill:#fff}.dropzone .dz-preview.dz-processing .dz-progress{opacity:1;-webkit-transition:all .2s linear;transition:all .2s linear}.dropzone .dz-preview.dz-complete .dz-progress{opacity:0;-webkit-transition:opacity .4s ease-in;transition:opacity .4s ease-in}.dropzone .dz-preview:not(.dz-processing) .dz-progress{-webkit-animation:pulse 6s ease infinite;animation:pulse 6s ease infinite}.dropzone .dz-preview .dz-progress{opacity:1;z-index:1000;pointer-events:none;position:absolute;height:20px;top:50%;margin-top:-10px;left:15%;right:15%;border:3px solid rgba(0,0,0,.8);background:rgba(0,0,0,.8);border-radius:10px;overflow:hidden}.dropzone .dz-preview .dz-progress .dz-upload{background:#fff;display:block;position:relative;height:100%;width:0;-webkit-transition:width 300ms ease-in-out;transition:width 300ms ease-in-out;border-radius:17px}.dropzone .dz-preview.dz-error .dz-error-message{display:block}.dropzone .dz-preview.dz-error:hover .dz-error-message{opacity:1;pointer-events:auto}.dropzone .dz-preview .dz-error-message{pointer-events:none;z-index:1000;position:absolute;display:block;display:none;opacity:0;-webkit-transition:opacity .3s ease;transition:opacity .3s ease;border-radius:8px;font-size:13px;top:130px;left:-10px;width:140px;background:#b10606;padding:.5em 1em;color:#fff}.dropzone .dz-preview .dz-error-message:after{content:"";position:absolute;top:-6px;left:64px;width:0;height:0;border-left:6px solid transparent;border-right:6px solid transparent;border-bottom:6px solid #b10606}
+
+/*!***********************************************************************************************************************************************!*\
+  !*** css ./node_modules/css-loader/dist/cjs.js!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./src/css/style.css (1) ***!
+  \***********************************************************************************************************************************************/
+/*! tailwindcss v4.0.8 | MIT License | https://tailwindcss.com */
+@layer theme, base, components, utilities;
+@layer theme {
+  :root, :host {
+    --color-orange-50: #fff6ed;
+    --color-orange-400: #fd853a;
+    --color-orange-500: #fb6514;
+    --color-blue-500: oklch(0.623 0.214 259.815);
+    --color-gray-50: #f9fafb;
+    --color-gray-100: #f2f4f7;
+    --color-gray-200: #e4e7ec;
+    --color-gray-300: #d0d5dd;
+    --color-gray-400: #98a2b3;
+    --color-gray-500: #667085;
+    --color-gray-600: #475467;
+    --color-gray-700: #344054;
+    --color-gray-800: #1d2939;
+    --color-gray-900: #101828;
+    --color-black: #101828;
+    --color-white: #ffffff;
+    --spacing: 0.25rem;
+    --container-xs: 20rem;
+    --container-md: 28rem;
+    --text-xs: 0.75rem;
+    --text-xs--line-height: calc(1 / 0.75);
+    --text-sm: 0.875rem;
+    --text-sm--line-height: calc(1.25 / 0.875);
+    --text-base: 1rem;
+    --text-base--line-height: calc(1.5 / 1);
+    --text-lg: 1.125rem;
+    --text-lg--line-height: calc(1.75 / 1.125);
+    --text-xl: 1.25rem;
+    --text-xl--line-height: calc(1.75 / 1.25);
+    --text-2xl: 1.5rem;
+    --text-2xl--line-height: calc(2 / 1.5);
+    --font-weight-normal: 400;
+    --font-weight-medium: 500;
+    --font-weight-semibold: 600;
+    --font-weight-bold: 700;
+    --leading-tight: 1.25;
+    --leading-normal: 1.5;
+    --radius-sm: 0.25rem;
+    --radius-md: 0.375rem;
+    --radius-lg: 0.5rem;
+    --radius-xl: 0.75rem;
+    --radius-2xl: 1rem;
+    --radius-3xl: 1.5rem;
+    --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+    --animate-spin: spin 1s linear infinite;
+    --animate-ping: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
+    --aspect-video: 16 / 9;
+    --default-transition-duration: 150ms;
+    --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    --default-font-family: var(--font-sans);
+    --default-font-feature-settings: var(--font-sans--font-feature-settings);
+    --default-font-variation-settings: var(
+      --font-sans--font-variation-settings
+    );
+    --default-mono-font-family: var(--font-mono);
+    --default-mono-font-feature-settings: var(
+      --font-mono--font-feature-settings
+    );
+    --default-mono-font-variation-settings: var(
+      --font-mono--font-variation-settings
+    );
+    --font-outfit: Outfit, sans-serif;
+    --breakpoint-2xl: 1536px;
+    --text-title-2xl: 72px;
+    --text-title-2xl--line-height: 90px;
+    --text-title-md: 36px;
+    --text-title-md--line-height: 44px;
+    --text-title-sm: 30px;
+    --text-title-sm--line-height: 38px;
+    --text-theme-xl: 20px;
+    --text-theme-xl--line-height: 30px;
+    --text-theme-sm: 14px;
+    --text-theme-sm--line-height: 20px;
+    --text-theme-xs: 12px;
+    --text-theme-xs--line-height: 18px;
+    --color-brand-50: #ecf3ff;
+    --color-brand-100: #dde9ff;
+    --color-brand-300: #9cb9ff;
+    --color-brand-400: #7592ff;
+    --color-brand-500: #465fff;
+    --color-brand-600: #3641f5;
+    --color-brand-800: #252dae;
+    --color-brand-950: #161950;
+    --color-blue-light-50: #f0f9ff;
+    --color-blue-light-500: #0ba5ec;
+    --color-gray-dark: #1a2231;
+    --color-success-50: #ecfdf3;
+    --color-success-300: #6ce9a6;
+    --color-success-500: #12b76a;
+    --color-success-600: #039855;
+    --color-success-700: #027a48;
+    --color-success-800: #05603a;
+    --color-error-50: #fef3f2;
+    --color-error-300: #fda29b;
+    --color-error-500: #f04438;
+    --color-error-600: #d92d20;
+    --color-error-700: #b42318;
+    --color-error-800: #912018;
+    --color-warning-50: #fffaeb;
+    --color-warning-400: #fdb022;
+    --color-warning-500: #f79009;
+    --color-warning-600: #dc6803;
+    --color-warning-700: #b54708;
+    --color-theme-pink-500: #ee46bc;
+    --color-theme-purple-500: #7a5af8;
+    --z-index-1: 1;
+    --z-index-9: 9;
+    --z-index-999: 999;
+    --z-index-9999: 9999;
+    --z-index-99999: 99999;
+    --z-index-999999: 999999;
+  }
+}
+@layer base {
+  ::-ms-backdrop {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+  ::-webkit-file-upload-button {
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+  *, ::after, ::before, ::backdrop, ::file-selector-button {
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+  html, :host {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    -moz-tab-size: 4;
+      -o-tab-size: 4;
+         tab-size: 4;
+    font-family: var( --default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" );
+    -webkit-font-feature-settings: var(--default-font-feature-settings, normal);
+            font-feature-settings: var(--default-font-feature-settings, normal);
+    font-variation-settings: var( --default-font-variation-settings, normal );
+    -webkit-tap-highlight-color: transparent;
+  }
+  body {
+    line-height: inherit;
+  }
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+  abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+  a {
+    color: inherit;
+    -webkit-text-decoration: inherit;
+    text-decoration: inherit;
+  }
+  b, strong {
+    font-weight: bolder;
+  }
+  code, kbd, samp, pre {
+    font-family: var( --default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace );
+    -webkit-font-feature-settings: var( --default-mono-font-feature-settings, normal );
+            font-feature-settings: var( --default-mono-font-feature-settings, normal );
+    font-variation-settings: var( --default-mono-font-variation-settings, normal );
+    font-size: 1em;
+  }
+  small {
+    font-size: 80%;
+  }
+  sub, sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  sub {
+    bottom: -0.25em;
+  }
+  sup {
+    top: -0.5em;
+  }
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+  :-moz-focusring {
+    outline: auto;
+  }
+  progress {
+    vertical-align: baseline;
+  }
+  summary {
+    display: list-item;
+  }
+  ol, ul, menu {
+    list-style: none;
+  }
+  img, svg, video, canvas, audio, iframe, embed, object {
+    display: block;
+    vertical-align: middle;
+  }
+  img, video {
+    max-width: 100%;
+    height: auto;
+  }
+  ::-webkit-file-upload-button {
+    font: inherit;
+    -webkit-font-feature-settings: inherit;
+            font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+  button, input, select, optgroup, textarea, ::file-selector-button {
+    font: inherit;
+    -webkit-font-feature-settings: inherit;
+            font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+  :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+  :where(select:is([multiple], [size])) optgroup option {
+    -webkit-padding-start: 20px;
+            padding-inline-start: 20px;
+  }
+  ::-webkit-file-upload-button {
+    -webkit-margin-end: 4px;
+            margin-inline-end: 4px;
+  }
+  ::file-selector-button {
+    -webkit-margin-end: 4px;
+            margin-inline-end: 4px;
+  }
+  ::-webkit-input-placeholder {
+    opacity: 1;
+    color: color-mix(in oklab, currentColor 50%, transparent);
+  }
+  ::-moz-placeholder {
+    opacity: 1;
+    color: color-mix(in oklab, currentColor 50%, transparent);
+  }
+  :-ms-input-placeholder {
+    opacity: 1;
+    color: color-mix(in oklab, currentColor 50%, transparent);
+  }
+  ::-ms-input-placeholder {
+    opacity: 1;
+    color: color-mix(in oklab, currentColor 50%, transparent);
+  }
+  ::placeholder {
+    opacity: 1;
+    color: color-mix(in oklab, currentColor 50%, transparent);
+  }
+  textarea {
+    resize: vertical;
+  }
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  ::-webkit-date-and-time-value {
+    min-height: 1lh;
+    text-align: inherit;
+  }
+  ::-webkit-datetime-edit {
+    display: -webkit-inline-box;
+    display: inline-flex;
+  }
+  ::-webkit-datetime-edit-fields-wrapper {
+    padding: 0;
+  }
+  ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month-field, ::-webkit-datetime-edit-day-field, ::-webkit-datetime-edit-hour-field, ::-webkit-datetime-edit-minute-field, ::-webkit-datetime-edit-second-field, ::-webkit-datetime-edit-millisecond-field, ::-webkit-datetime-edit-meridiem-field {
+    padding-block: 0;
+  }
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button;
+            appearance: button;
+  }
+  button, input:where([type="button"], [type="reset"], [type="submit"]), ::file-selector-button {
+    -webkit-appearance: button;
+       -moz-appearance: button;
+            appearance: button;
+  }
+  ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
+    height: auto;
+  }
+  [hidden]:where(:not([hidden="until-found"])) {
+    display: none !important;
+  }
+}
+@layer utilities {
+  .pointer-events-none {
+    pointer-events: none;
+  }
+  .menu-item-arrow {
+    position: absolute;
+    top: calc(1/2 * 100%);
+    right: calc(var(--spacing) * 2.5);
+    --tw-translate-y: calc(calc(1/2 * 100%) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+  }
+  .menu-dropdown-item {
+    position: relative;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+    gap: calc(var(--spacing) * 3);
+    border-radius: var(--radius-lg);
+    padding-inline: calc(var(--spacing) * 3);
+    padding-block: calc(var(--spacing) * 2.5);
+    font-size: var(--text-theme-sm);
+    line-height: var(--tw-leading, var(--text-theme-sm--line-height));
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+  }
+  .menu-item {
+    position: relative;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+    gap: calc(var(--spacing) * 3);
+    border-radius: var(--radius-lg);
+    padding-inline: calc(var(--spacing) * 3);
+    padding-block: calc(var(--spacing) * 2);
+    font-size: var(--text-theme-sm);
+    line-height: var(--tw-leading, var(--text-theme-sm--line-height));
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+  }
+  .absolute {
+    position: absolute;
+  }
+  .fixed {
+    position: fixed;
+  }
+  .relative {
+    position: relative;
+  }
+  .static {
+    position: static;
+  }
+  .sticky {
+    position: sticky;
+  }
+  .inset-0 {
+    inset: calc(var(--spacing) * 0);
+  }
+  .inset-y-0 {
+    inset-block: calc(var(--spacing) * 0);
+  }
+  .top-0 {
+    top: calc(var(--spacing) * 0);
+  }
+  .top-0\.5 {
+    top: calc(var(--spacing) * 0.5);
+  }
+  .top-1\/2 {
+    top: calc(1/2 * 100%);
+  }
+  .top-5 {
+    top: calc(var(--spacing) * 5);
+  }
+  .top-\[85\%\] {
+    top: 85%;
+  }
+  .top-full {
+    top: 100%;
+  }
+  .-right-\[240px\] {
+    right: calc(240px * -1);
+  }
+  .right-0 {
+    right: calc(var(--spacing) * 0);
+  }
+  .right-2\.5 {
+    right: calc(var(--spacing) * 2.5);
+  }
+  .right-3 {
+    right: calc(var(--spacing) * 3);
+  }
+  .right-3\.5 {
+    right: calc(var(--spacing) * 3.5);
+  }
+  .right-4 {
+    right: calc(var(--spacing) * 4);
+  }
+  .right-5 {
+    right: calc(var(--spacing) * 5);
+  }
+  .right-6 {
+    right: calc(var(--spacing) * 6);
+  }
+  .right-auto {
+    right: auto;
+  }
+  .bottom-0 {
+    bottom: calc(var(--spacing) * 0);
+  }
+  .bottom-6 {
+    bottom: calc(var(--spacing) * 6);
+  }
+  .left-0 {
+    left: calc(var(--spacing) * 0);
+  }
+  .left-0\.5 {
+    left: calc(var(--spacing) * 0.5);
+  }
+  .left-1\/2 {
+    left: calc(1/2 * 100%);
+  }
+  .left-4 {
+    left: calc(var(--spacing) * 4);
+  }
+  .-z-1 {
+    z-index: calc(var(--z-index-1) * -1);
+  }
+  .z-1 {
+    z-index: var(--z-index-1);
+  }
+  .z-9 {
+    z-index: var(--z-index-9);
+  }
+  .z-10 {
+    z-index: 10;
+  }
+  .z-20 {
+    z-index: 20;
+  }
+  .z-30 {
+    z-index: 30;
+  }
+  .z-40 {
+    z-index: 40;
+  }
+  .z-50 {
+    z-index: 50;
+  }
+  .z-999 {
+    z-index: var(--z-index-999);
+  }
+  .z-9999 {
+    z-index: var(--z-index-9999);
+  }
+  .z-99999 {
+    z-index: var(--z-index-99999);
+  }
+  .z-999999 {
+    z-index: var(--z-index-999999);
+  }
+  .order-2 {
+    -webkit-box-ordinal-group: 3;
+        -ms-flex-order: 2;
+            order: 2;
+  }
+  .order-3 {
+    -webkit-box-ordinal-group: 4;
+        -ms-flex-order: 3;
+            order: 3;
+  }
+  .col-span-2 {
+    grid-column: span 2 / span 2;
+  }
+  .col-span-12 {
+    grid-column: span 12 / span 12;
+  }
+  .m-0\! {
+    margin: calc(var(--spacing) * 0) !important;
+  }
+  .-mx-4 {
+    margin-inline: calc(var(--spacing) * -4);
+  }
+  .mx-2 {
+    margin-inline: calc(var(--spacing) * 2);
+  }
+  .mx-auto {
+    margin-inline: auto;
+  }
+  .-my-6 {
+    margin-block: calc(var(--spacing) * -6);
+  }
+  .my-6 {
+    margin-block: calc(var(--spacing) * 6);
+  }
+  .-mt-0\.5 {
+    margin-top: calc(var(--spacing) * -0.5);
+  }
+  .mt-0\.5 {
+    margin-top: calc(var(--spacing) * 0.5);
+  }
+  .mt-1 {
+    margin-top: calc(var(--spacing) * 1);
+  }
+  .mt-1\.5 {
+    margin-top: calc(var(--spacing) * 1.5);
+  }
+  .mt-2 {
+    margin-top: calc(var(--spacing) * 2);
+  }
+  .mt-3 {
+    margin-top: calc(var(--spacing) * 3);
+  }
+  .mt-5 {
+    margin-top: calc(var(--spacing) * 5);
+  }
+  .mt-6 {
+    margin-top: calc(var(--spacing) * 6);
+  }
+  .mt-7 {
+    margin-top: calc(var(--spacing) * 7);
+  }
+  .mt-8 {
+    margin-top: calc(var(--spacing) * 8);
+  }
+  .mt-10 {
+    margin-top: calc(var(--spacing) * 10);
+  }
+  .mt-20 {
+    margin-top: calc(var(--spacing) * 20);
+  }
+  .mt-\[17px\] {
+    margin-top: 17px;
+  }
+  .mr-1 {
+    margin-right: calc(var(--spacing) * 1);
+  }
+  .mr-2 {
+    margin-right: calc(var(--spacing) * 2);
+  }
+  .mr-3 {
+    margin-right: calc(var(--spacing) * 3);
+  }
+  .mb-0\.5 {
+    margin-bottom: calc(var(--spacing) * 0.5);
+  }
+  .mb-1 {
+    margin-bottom: calc(var(--spacing) * 1);
+  }
+  .mb-1\.5 {
+    margin-bottom: calc(var(--spacing) * 1.5);
+  }
+  .mb-2 {
+    margin-bottom: calc(var(--spacing) * 2);
+  }
+  .mb-3 {
+    margin-bottom: calc(var(--spacing) * 3);
+  }
+  .mb-4 {
+    margin-bottom: calc(var(--spacing) * 4);
+  }
+  .mb-5 {
+    margin-bottom: calc(var(--spacing) * 5);
+  }
+  .mb-6 {
+    margin-bottom: calc(var(--spacing) * 6);
+  }
+  .mb-8 {
+    margin-bottom: calc(var(--spacing) * 8);
+  }
+  .mb-10 {
+    margin-bottom: calc(var(--spacing) * 10);
+  }
+  .mb-\[22px\] {
+    margin-bottom: 22px;
+  }
+  .-ml-4 {
+    margin-left: calc(var(--spacing) * -4);
+  }
+  .-ml-5 {
+    margin-left: calc(var(--spacing) * -5);
+  }
+  .menu-dropdown-badge {
+    display: block;
+    border-radius: calc(infinity * 1px);
+    padding-inline: calc(var(--spacing) * 2.5);
+    padding-block: calc(var(--spacing) * 0.5);
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-brand-500);
+    text-transform: uppercase;
+    &:is(.dark *) {
+      color: var(--color-brand-400);
+    }
+  }
+  .no-scrollbar {
+    &::-webkit-scrollbar {
+      display: none;
+    }
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .block {
+    display: block;
+  }
+  .flex {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+  .grid {
+    display: grid;
+  }
+  .hidden {
+    display: none;
+  }
+  .inline-block {
+    display: inline-block;
+  }
+  .inline-flex {
+    display: -webkit-inline-box;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+  }
+  .table {
+    display: table;
+  }
+  .aspect-4\/3 {
+    aspect-ratio: 4/3;
+  }
+  .aspect-21\/9 {
+    aspect-ratio: 21/9;
+  }
+  .aspect-square {
+    aspect-ratio: 1 / 1;
+  }
+  .aspect-video {
+    aspect-ratio: var(--aspect-video);
+  }
+  .custom-scrollbar {
+    &::-webkit-scrollbar {
+      width: calc(var(--spacing) * 1.5);
+      height: calc(var(--spacing) * 1.5);
+    }
+    &::-webkit-scrollbar-track {
+      border-radius: calc(infinity * 1px);
+    }
+    &::-webkit-scrollbar-thumb {
+      border-radius: calc(infinity * 1px);
+      background-color: var(--color-gray-200);
+    }
+  }
+  .size-14 {
+    width: calc(var(--spacing) * 14);
+    height: calc(var(--spacing) * 14);
+  }
+  .h-1 {
+    height: calc(var(--spacing) * 1);
+  }
+  .h-1\.5 {
+    height: calc(var(--spacing) * 1.5);
+  }
+  .h-2 {
+    height: calc(var(--spacing) * 2);
+  }
+  .h-2\.5 {
+    height: calc(var(--spacing) * 2.5);
+  }
+  .h-3 {
+    height: calc(var(--spacing) * 3);
+  }
+  .h-3\.5 {
+    height: calc(var(--spacing) * 3.5);
+  }
+  .h-4 {
+    height: calc(var(--spacing) * 4);
+  }
+  .h-5 {
+    height: calc(var(--spacing) * 5);
+  }
+  .h-6 {
+    height: calc(var(--spacing) * 6);
+  }
+  .h-7 {
+    height: calc(var(--spacing) * 7);
+  }
+  .h-8 {
+    height: calc(var(--spacing) * 8);
+  }
+  .h-10 {
+    height: calc(var(--spacing) * 10);
+  }
+  .h-11 {
+    height: calc(var(--spacing) * 11);
+  }
+  .h-12 {
+    height: calc(var(--spacing) * 12);
+  }
+  .h-14 {
+    height: calc(var(--spacing) * 14);
+  }
+  .h-16 {
+    height: calc(var(--spacing) * 16);
+  }
+  .h-20 {
+    height: calc(var(--spacing) * 20);
+  }
+  .h-\[50px\] {
+    height: 50px;
+  }
+  .h-\[52px\] {
+    height: 52px;
+  }
+  .h-\[68px\] {
+    height: 68px;
+  }
+  .h-\[212px\] {
+    height: 212px;
+  }
+  .h-\[372px\] {
+    height: 372px;
+  }
+  .h-\[450px\] {
+    height: 450px;
+  }
+  .h-\[480px\] {
+    height: 480px;
+  }
+  .h-auto {
+    height: auto;
+  }
+  .h-fit {
+    height: -webkit-fit-content;
+    height: -moz-fit-content;
+    height: fit-content;
+  }
+  .h-full {
+    height: 100%;
+  }
+  .h-screen {
+    height: 100vh;
+  }
+  .max-h-\[195px\] {
+    max-height: 195px;
+  }
+  .min-h-screen {
+    min-height: 100vh;
+  }
+  .w-1 {
+    width: calc(var(--spacing) * 1);
+  }
+  .w-2 {
+    width: calc(var(--spacing) * 2);
+  }
+  .w-5 {
+    width: calc(var(--spacing) * 5);
+  }
+  .w-6 {
+    width: calc(var(--spacing) * 6);
+  }
+  .w-7 {
+    width: calc(var(--spacing) * 7);
+  }
+  .w-8 {
+    width: calc(var(--spacing) * 8);
+  }
+  .w-10 {
+    width: calc(var(--spacing) * 10);
+  }
+  .w-11 {
+    width: calc(var(--spacing) * 11);
+  }
+  .w-12 {
+    width: calc(var(--spacing) * 12);
+  }
+  .w-16 {
+    width: calc(var(--spacing) * 16);
+  }
+  .w-20 {
+    width: calc(var(--spacing) * 20);
+  }
+  .w-40 {
+    width: calc(var(--spacing) * 40);
+  }
+  .w-\[23\%\] {
+    width: 23%;
+  }
+  .w-\[46px\] {
+    width: 46px;
+  }
+  .w-\[50px\] {
+    width: 50px;
+  }
+  .w-\[52px\] {
+    width: 52px;
+  }
+  .w-\[68px\] {
+    width: 68px;
+  }
+  .w-\[79\%\] {
+    width: 79%;
+  }
+  .w-\[252px\] {
+    width: 252px;
+  }
+  .w-\[260px\] {
+    width: 260px;
+  }
+  .w-\[290px\] {
+    width: 290px;
+  }
+  .w-\[350px\] {
+    width: 350px;
+  }
+  .w-fit {
+    width: -webkit-fit-content;
+    width: -moz-fit-content;
+    width: fit-content;
+  }
+  .w-full {
+    width: 100%;
+  }
+  .w-px {
+    width: 1px;
+  }
+  .w-screen {
+    width: 100vw;
+  }
+  .max-w-\(--breakpoint-2xl\) {
+    max-width: var(--breakpoint-2xl);
+  }
+  .max-w-1\.5 {
+    max-width: calc(var(--spacing) * 1.5);
+  }
+  .max-w-2 {
+    max-width: calc(var(--spacing) * 2);
+  }
+  .max-w-2\.5 {
+    max-width: calc(var(--spacing) * 2.5);
+  }
+  .max-w-3 {
+    max-width: calc(var(--spacing) * 3);
+  }
+  .max-w-3\.5 {
+    max-width: calc(var(--spacing) * 3.5);
+  }
+  .max-w-4 {
+    max-width: calc(var(--spacing) * 4);
+  }
+  .max-w-6 {
+    max-width: calc(var(--spacing) * 6);
+  }
+  .max-w-8 {
+    max-width: calc(var(--spacing) * 8);
+  }
+  .max-w-10 {
+    max-width: calc(var(--spacing) * 10);
+  }
+  .max-w-11 {
+    max-width: calc(var(--spacing) * 11);
+  }
+  .max-w-12 {
+    max-width: calc(var(--spacing) * 12);
+  }
+  .max-w-14 {
+    max-width: calc(var(--spacing) * 14);
+  }
+  .max-w-16 {
+    max-width: calc(var(--spacing) * 16);
+  }
+  .max-w-60 {
+    max-width: calc(var(--spacing) * 60);
+  }
+  .max-w-\[100px\] {
+    max-width: 100px;
+  }
+  .max-w-\[140px\] {
+    max-width: 140px;
+  }
+  .max-w-\[242px\] {
+    max-width: 242px;
+  }
+  .max-w-\[250px\] {
+    max-width: 250px;
+  }
+  .max-w-\[290px\] {
+    max-width: 290px;
+  }
+  .max-w-\[380px\] {
+    max-width: 380px;
+  }
+  .max-w-\[630px\] {
+    max-width: 630px;
+  }
+  .max-w-\[700px\] {
+    max-width: 700px;
+  }
+  .max-w-full {
+    max-width: 100%;
+  }
+  .max-w-md {
+    max-width: var(--container-md);
+  }
+  .max-w-xs {
+    max-width: var(--container-xs);
+  }
+  .min-w-\[500px\] {
+    min-width: 500px;
+  }
+  .min-w-\[650px\] {
+    min-width: 650px;
+  }
+  .min-w-\[700px\] {
+    min-width: 700px;
+  }
+  .min-w-\[1000px\] {
+    min-width: 1000px;
+  }
+  .min-w-full {
+    min-width: 100%;
+  }
+  .flex-1 {
+    -webkit-box-flex: 1;
+        -ms-flex: 1;
+            flex: 1;
+  }
+  .flex-auto {
+    -webkit-box-flex: 1;
+        -ms-flex: auto;
+            flex: auto;
+  }
+  .flex-initial {
+    -webkit-box-flex: 0;
+        -ms-flex: 0 auto;
+            flex: 0 auto;
+  }
+  .grow {
+    -webkit-box-flex: 1;
+        -ms-flex-positive: 1;
+            flex-grow: 1;
+  }
+  .-translate-x-1\/2 {
+    --tw-translate-x: calc(calc(1/2 * 100%) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .-translate-x-full {
+    --tw-translate-x: -100%;
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .translate-x-0 {
+    --tw-translate-x: calc(var(--spacing) * 0);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .translate-x-full {
+    --tw-translate-x: 100%;
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .-translate-y-1\/2 {
+    --tw-translate-y: calc(calc(1/2 * 100%) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .-translate-y-\[85\%\] {
+    --tw-translate-y: calc(85% * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .menu-item-arrow-active {
+    rotate: 180deg;
+    stroke: var(--color-brand-500);
+    &:is(.dark *) {
+      stroke: var(--color-brand-400);
+    }
+  }
+  .rotate-180 {
+    rotate: 180deg;
+  }
+  .transform {
+    -webkit-transform: var(--tw-rotate-x) var(--tw-rotate-y) var(--tw-rotate-z) var(--tw-skew-x) var(--tw-skew-y);
+            transform: var(--tw-rotate-x) var(--tw-rotate-y) var(--tw-rotate-z) var(--tw-skew-x) var(--tw-skew-y);
+  }
+  .animate-ping {
+    -webkit-animation: var(--animate-ping);
+            animation: var(--animate-ping);
+  }
+  .animate-spin {
+    -webkit-animation: var(--animate-spin);
+            animation: var(--animate-spin);
+  }
+  .cursor-pointer {
+    cursor: pointer;
+  }
+  .appearance-none {
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
+  }
+  .grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+  .grid-cols-12 {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+  }
+  .flex-col {
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+            flex-direction: column;
+  }
+  .flex-row-reverse {
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: reverse;
+        -ms-flex-direction: row-reverse;
+            flex-direction: row-reverse;
+  }
+  .flex-wrap {
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+  }
+  .items-center {
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+  }
+  .items-end {
+    -webkit-box-align: end;
+        -ms-flex-align: end;
+            align-items: flex-end;
+  }
+  .items-start {
+    -webkit-box-align: start;
+        -ms-flex-align: start;
+            align-items: flex-start;
+  }
+  .justify-between {
+    -webkit-box-pack: justify;
+        -ms-flex-pack: justify;
+            justify-content: space-between;
+  }
+  .justify-center {
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
+  }
+  .justify-end {
+    -webkit-box-pack: end;
+        -ms-flex-pack: end;
+            justify-content: flex-end;
+  }
+  .gap-0\.5 {
+    gap: calc(var(--spacing) * 0.5);
+  }
+  .gap-1 {
+    gap: calc(var(--spacing) * 1);
+  }
+  .gap-1\.5 {
+    gap: calc(var(--spacing) * 1.5);
+  }
+  .gap-2 {
+    gap: calc(var(--spacing) * 2);
+  }
+  .gap-3 {
+    gap: calc(var(--spacing) * 3);
+  }
+  .gap-4 {
+    gap: calc(var(--spacing) * 4);
+  }
+  .gap-5 {
+    gap: calc(var(--spacing) * 5);
+  }
+  .gap-6 {
+    gap: calc(var(--spacing) * 6);
+  }
+  .gap-8 {
+    gap: calc(var(--spacing) * 8);
+  }
+  .gap-9 {
+    gap: calc(var(--spacing) * 9);
+  }
+  .space-y-1 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      -webkit-margin-before: calc(calc(var(--spacing) * 1) * var(--tw-space-y-reverse));
+              margin-block-start: calc(calc(var(--spacing) * 1) * var(--tw-space-y-reverse));
+      -webkit-margin-after: calc(calc(var(--spacing) * 1) * calc(1 - var(--tw-space-y-reverse)));
+              margin-block-end: calc(calc(var(--spacing) * 1) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
+  .space-y-5 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      -webkit-margin-before: calc(calc(var(--spacing) * 5) * var(--tw-space-y-reverse));
+              margin-block-start: calc(calc(var(--spacing) * 5) * var(--tw-space-y-reverse));
+      -webkit-margin-after: calc(calc(var(--spacing) * 5) * calc(1 - var(--tw-space-y-reverse)));
+              margin-block-end: calc(calc(var(--spacing) * 5) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
+  .space-y-6 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      -webkit-margin-before: calc(calc(var(--spacing) * 6) * var(--tw-space-y-reverse));
+              margin-block-start: calc(calc(var(--spacing) * 6) * var(--tw-space-y-reverse));
+      -webkit-margin-after: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-y-reverse)));
+              margin-block-end: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
+  .gap-x-6 {
+    -webkit-column-gap: calc(var(--spacing) * 6);
+       -moz-column-gap: calc(var(--spacing) * 6);
+            column-gap: calc(var(--spacing) * 6);
+  }
+  .-space-x-2 {
+    :where(& > :not(:last-child)) {
+      --tw-space-x-reverse: 0;
+      -webkit-margin-start: calc(calc(var(--spacing) * -2) * var(--tw-space-x-reverse));
+              margin-inline-start: calc(calc(var(--spacing) * -2) * var(--tw-space-x-reverse));
+      -webkit-margin-end: calc(calc(var(--spacing) * -2) * calc(1 - var(--tw-space-x-reverse)));
+              margin-inline-end: calc(calc(var(--spacing) * -2) * calc(1 - var(--tw-space-x-reverse)));
+    }
+  }
+  .gap-y-5 {
+    row-gap: calc(var(--spacing) * 5);
+  }
+  .divide-y {
+    :where(& > :not(:last-child)) {
+      --tw-divide-y-reverse: 0;
+      border-bottom-style: var(--tw-border-style);
+      border-top-style: var(--tw-border-style);
+      border-top-width: calc(1px * var(--tw-divide-y-reverse));
+      border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+    }
+  }
+  .divide-gray-100 {
+    :where(& > :not(:last-child)) {
+      border-color: var(--color-gray-100);
+    }
+  }
+  .overflow-hidden {
+    overflow: hidden;
+  }
+  .overflow-x-auto {
+    overflow-x: auto;
+  }
+  .overflow-x-hidden {
+    overflow-x: hidden;
+  }
+  .overflow-y-auto {
+    overflow-y: auto;
+  }
+  .overflow-y-hidden {
+    overflow-y: hidden;
+  }
+  .rounded-2xl {
+    border-radius: var(--radius-2xl);
+  }
+  .rounded-3xl {
+    border-radius: var(--radius-3xl);
+  }
+  .rounded-full {
+    border-radius: calc(infinity * 1px);
+  }
+  .rounded-lg {
+    border-radius: var(--radius-lg);
+  }
+  .rounded-md {
+    border-radius: var(--radius-md);
+  }
+  .rounded-sm {
+    border-radius: var(--radius-sm);
+  }
+  .rounded-xl {
+    border-radius: var(--radius-xl);
+  }
+  .rounded-t {
+    border-top-left-radius: 0.25rem;
+    border-top-right-radius: 0.25rem;
+  }
+  .rounded-l-lg {
+    border-top-left-radius: var(--radius-lg);
+    border-bottom-left-radius: var(--radius-lg);
+  }
+  .rounded-r-lg {
+    border-top-right-radius: var(--radius-lg);
+    border-bottom-right-radius: var(--radius-lg);
+  }
+  .border {
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+  }
+  .border-0 {
+    border-style: var(--tw-border-style);
+    border-width: 0px;
+  }
+  .border-2 {
+    border-style: var(--tw-border-style);
+    border-width: 2px;
+  }
+  .border-4 {
+    border-style: var(--tw-border-style);
+    border-width: 4px;
+  }
+  .border-\[0\.7px\] {
+    border-style: var(--tw-border-style);
+    border-width: 0.7px;
+  }
+  .border-\[1\.5px\] {
+    border-style: var(--tw-border-style);
+    border-width: 1.5px;
+  }
+  .border-\[1\.25px\] {
+    border-style: var(--tw-border-style);
+    border-width: 1.25px;
+  }
+  .border-y {
+    border-block-style: var(--tw-border-style);
+    border-block-width: 1px;
+  }
+  .border-t {
+    border-top-style: var(--tw-border-style);
+    border-top-width: 1px;
+  }
+  .border-r {
+    border-right-style: var(--tw-border-style);
+    border-right-width: 1px;
+  }
+  .border-b {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 1px;
+  }
+  .border-l {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 1px;
+  }
+  .border-l-2 {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 2px;
+  }
+  .border-dashed\! {
+    --tw-border-style: dashed;
+    border-style: dashed !important;
+  }
+  .border-solid {
+    --tw-border-style: solid;
+    border-style: solid;
+  }
+  .border-blue-light-500 {
+    border-color: var(--color-blue-light-500);
+  }
+  .border-brand-500 {
+    border-color: var(--color-brand-500);
+  }
+  .border-error-300 {
+    border-color: var(--color-error-300);
+  }
+  .border-error-500 {
+    border-color: var(--color-error-500);
+  }
+  .border-gray-100 {
+    border-color: var(--color-gray-100);
+  }
+  .border-gray-200 {
+    border-color: var(--color-gray-200);
+  }
+  .border-gray-300 {
+    border-color: var(--color-gray-300);
+  }
+  .border-gray-300\! {
+    border-color: var(--color-gray-300) !important;
+  }
+  .border-success-300 {
+    border-color: var(--color-success-300);
+  }
+  .border-success-500 {
+    border-color: var(--color-success-500);
+  }
+  .border-transparent {
+    border-color: transparent;
+  }
+  .border-warning-500 {
+    border-color: var(--color-warning-500);
+  }
+  .border-white {
+    border-color: var(--color-white);
+  }
+  .border-t-transparent {
+    border-top-color: transparent;
+  }
+  .menu-item-inactive {
+    color: var(--color-gray-700);
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-100);
+      }
+    }
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-gray-700);
+      }
+    }
+    &:is(.dark *) {
+      color: var(--color-gray-300);
+    }
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: color-mix(in oklab, var(--color-white) 5%, transparent);
+        }
+      }
+    }
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          color: var(--color-gray-300);
+        }
+      }
+    }
+  }
+  .menu-dropdown-item-active {
+    background-color: var(--color-brand-50);
+    color: var(--color-brand-500);
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-brand-500) 12%, transparent);
+    }
+    &:is(.dark *) {
+      color: var(--color-brand-400);
+    }
+  }
+  .menu-dropdown-item-inactive {
+    color: var(--color-gray-700);
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-100);
+      }
+    }
+    &:is(.dark *) {
+      color: var(--color-gray-300);
+    }
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: color-mix(in oklab, var(--color-white) 5%, transparent);
+        }
+      }
+    }
+  }
+  .menu-item-active {
+    background-color: var(--color-brand-50);
+    color: var(--color-brand-500);
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-brand-500) 12%, transparent);
+    }
+    &:is(.dark *) {
+      color: var(--color-brand-400);
+    }
+  }
+  .menu-dropdown-badge-inactive {
+    background-color: var(--color-brand-50);
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        background-color: var(--color-brand-100);
+      }
+    }
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-brand-500) 15%, transparent);
+    }
+    &:is(.dark *) {
+      &:is(:where(.group):hover *) {
+        @media (hover: hover) {
+          background-color: color-mix(in oklab, var(--color-brand-500) 20%, transparent);
+        }
+      }
+    }
+  }
+  .menu-dropdown-badge-active {
+    background-color: var(--color-brand-100);
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-brand-500) 20%, transparent);
+    }
+  }
+  .bg-blue-500\/\[0\.08\] {
+    background-color: color-mix(in oklab, var(--color-blue-500) 8%, transparent);
+  }
+  .bg-blue-light-50 {
+    background-color: var(--color-blue-light-50);
+  }
+  .bg-blue-light-500 {
+    background-color: var(--color-blue-light-500);
+  }
+  .bg-brand-50 {
+    background-color: var(--color-brand-50);
+  }
+  .bg-brand-500 {
+    background-color: var(--color-brand-500);
+  }
+  .bg-brand-950 {
+    background-color: var(--color-brand-950);
+  }
+  .bg-error-50 {
+    background-color: var(--color-error-50);
+  }
+  .bg-error-500 {
+    background-color: var(--color-error-500);
+  }
+  .bg-gray-50 {
+    background-color: var(--color-gray-50);
+  }
+  .bg-gray-100 {
+    background-color: var(--color-gray-100);
+  }
+  .bg-gray-200 {
+    background-color: var(--color-gray-200);
+  }
+  .bg-gray-300 {
+    background-color: var(--color-gray-300);
+  }
+  .bg-gray-400 {
+    background-color: var(--color-gray-400);
+  }
+  .bg-gray-400\/50 {
+    background-color: color-mix(in oklab, var(--color-gray-400) 50%, transparent);
+  }
+  .bg-gray-500 {
+    background-color: var(--color-gray-500);
+  }
+  .bg-gray-700 {
+    background-color: var(--color-gray-700);
+  }
+  .bg-gray-800 {
+    background-color: var(--color-gray-800);
+  }
+  .bg-gray-900 {
+    background-color: var(--color-gray-900);
+  }
+  .bg-gray-900\/50 {
+    background-color: color-mix(in oklab, var(--color-gray-900) 50%, transparent);
+  }
+  .bg-orange-400 {
+    background-color: var(--color-orange-400);
+  }
+  .bg-orange-500\/\[0\.08\] {
+    background-color: color-mix(in oklab, var(--color-orange-500) 8%, transparent);
+  }
+  .bg-success-50 {
+    background-color: var(--color-success-50);
+  }
+  .bg-success-500 {
+    background-color: var(--color-success-500);
+  }
+  .bg-success-500\/\[0\.08\] {
+    background-color: color-mix(in oklab, var(--color-success-500) 8%, transparent);
+  }
+  .bg-theme-pink-500\/\[0\.08\] {
+    background-color: color-mix(in oklab, var(--color-theme-pink-500) 8%, transparent);
+  }
+  .bg-theme-purple-500\/\[0\.08\] {
+    background-color: color-mix(in oklab, var(--color-theme-purple-500) 8%, transparent);
+  }
+  .bg-transparent {
+    background-color: transparent;
+  }
+  .bg-warning-50 {
+    background-color: var(--color-warning-50);
+  }
+  .bg-warning-500 {
+    background-color: var(--color-warning-500);
+  }
+  .bg-warning-500\/\[0\.08\] {
+    background-color: color-mix(in oklab, var(--color-warning-500) 8%, transparent);
+  }
+  .bg-white {
+    background-color: var(--color-white);
+  }
+  .bg-none {
+    background-image: none;
+  }
+  .menu-item-icon-inactive {
+    fill: var(--color-gray-500);
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        fill: var(--color-gray-700);
+      }
+    }
+    &:is(.dark *) {
+      fill: var(--color-gray-400);
+    }
+    &:is(.dark *) {
+      &:is(:where(.group):hover *) {
+        @media (hover: hover) {
+          fill: var(--color-gray-300);
+        }
+      }
+    }
+  }
+  .menu-item-icon-active {
+    fill: var(--color-brand-500);
+    &:is(.dark *) {
+      fill: var(--color-brand-400);
+    }
+  }
+  .fill-current {
+    fill: currentColor;
+  }
+  .fill-gray-500 {
+    fill: var(--color-gray-500);
+  }
+  .fill-gray-700 {
+    fill: var(--color-gray-700);
+  }
+  .fill-gray-800 {
+    fill: var(--color-gray-800);
+  }
+  .fill-white {
+    fill: var(--color-white);
+  }
+  .menu-item-arrow-inactive {
+    stroke: var(--color-gray-500);
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        stroke: var(--color-gray-700);
+      }
+    }
+    &:is(.dark *) {
+      stroke: var(--color-gray-400);
+    }
+    &:is(.dark *) {
+      &:is(:where(.group):hover *) {
+        @media (hover: hover) {
+          stroke: var(--color-gray-300);
+        }
+      }
+    }
+  }
+  .stroke-current {
+    stroke: currentColor;
+  }
+  .stroke-gray-200 {
+    stroke: var(--color-gray-200);
+  }
+  .stroke-gray-500 {
+    stroke: var(--color-gray-500);
+  }
+  .p-0\.5 {
+    padding: calc(var(--spacing) * 0.5);
+  }
+  .p-1 {
+    padding: calc(var(--spacing) * 1);
+  }
+  .p-2 {
+    padding: calc(var(--spacing) * 2);
+  }
+  .p-2\.5 {
+    padding: calc(var(--spacing) * 2.5);
+  }
+  .p-3 {
+    padding: calc(var(--spacing) * 3);
+  }
+  .p-4 {
+    padding: calc(var(--spacing) * 4);
+  }
+  .p-5 {
+    padding: calc(var(--spacing) * 5);
+  }
+  .p-6 {
+    padding: calc(var(--spacing) * 6);
+  }
+  .p-7 {
+    padding: calc(var(--spacing) * 7);
+  }
+  .p-8 {
+    padding: calc(var(--spacing) * 8);
+  }
+  .px-2 {
+    padding-inline: calc(var(--spacing) * 2);
+  }
+  .px-2\.5 {
+    padding-inline: calc(var(--spacing) * 2.5);
+  }
+  .px-3 {
+    padding-inline: calc(var(--spacing) * 3);
+  }
+  .px-3\.5 {
+    padding-inline: calc(var(--spacing) * 3.5);
+  }
+  .px-4 {
+    padding-inline: calc(var(--spacing) * 4);
+  }
+  .px-4\.5 {
+    padding-inline: calc(var(--spacing) * 4.5);
+  }
+  .px-5 {
+    padding-inline: calc(var(--spacing) * 5);
+  }
+  .px-6 {
+    padding-inline: calc(var(--spacing) * 6);
+  }
+  .px-7 {
+    padding-inline: calc(var(--spacing) * 7);
+  }
+  .px-\[7px\] {
+    padding-inline: 7px;
+  }
+  .py-0\.5 {
+    padding-block: calc(var(--spacing) * 0.5);
+  }
+  .py-1 {
+    padding-block: calc(var(--spacing) * 1);
+  }
+  .py-1\.5 {
+    padding-block: calc(var(--spacing) * 1.5);
+  }
+  .py-2 {
+    padding-block: calc(var(--spacing) * 2);
+  }
+  .py-2\.5 {
+    padding-block: calc(var(--spacing) * 2.5);
+  }
+  .py-3 {
+    padding-block: calc(var(--spacing) * 3);
+  }
+  .py-3\.5 {
+    padding-block: calc(var(--spacing) * 3.5);
+  }
+  .py-4 {
+    padding-block: calc(var(--spacing) * 4);
+  }
+  .py-5 {
+    padding-block: calc(var(--spacing) * 5);
+  }
+  .py-6 {
+    padding-block: calc(var(--spacing) * 6);
+  }
+  .py-6\.5 {
+    padding-block: calc(var(--spacing) * 6.5);
+  }
+  .py-7 {
+    padding-block: calc(var(--spacing) * 7);
+  }
+  .py-\[4\.5px\] {
+    padding-block: 4.5px;
+  }
+  .pt-4 {
+    padding-top: calc(var(--spacing) * 4);
+  }
+  .pt-5 {
+    padding-top: calc(var(--spacing) * 5);
+  }
+  .pt-8 {
+    padding-top: calc(var(--spacing) * 8);
+  }
+  .pt-10 {
+    padding-top: calc(var(--spacing) * 10);
+  }
+  .pr-1 {
+    padding-right: calc(var(--spacing) * 1);
+  }
+  .pr-2 {
+    padding-right: calc(var(--spacing) * 2);
+  }
+  .pr-2\.5 {
+    padding-right: calc(var(--spacing) * 2.5);
+  }
+  .pr-3 {
+    padding-right: calc(var(--spacing) * 3);
+  }
+  .pr-3\.5 {
+    padding-right: calc(var(--spacing) * 3.5);
+  }
+  .pr-4 {
+    padding-right: calc(var(--spacing) * 4);
+  }
+  .pr-8 {
+    padding-right: calc(var(--spacing) * 8);
+  }
+  .pr-10 {
+    padding-right: calc(var(--spacing) * 10);
+  }
+  .pr-11 {
+    padding-right: calc(var(--spacing) * 11);
+  }
+  .pr-14 {
+    padding-right: calc(var(--spacing) * 14);
+  }
+  .pr-\[84px\] {
+    padding-right: 84px;
+  }
+  .pr-\[90px\] {
+    padding-right: 90px;
+  }
+  .pb-3 {
+    padding-bottom: calc(var(--spacing) * 3);
+  }
+  .pb-4 {
+    padding-bottom: calc(var(--spacing) * 4);
+  }
+  .pb-5 {
+    padding-bottom: calc(var(--spacing) * 5);
+  }
+  .pb-7 {
+    padding-bottom: calc(var(--spacing) * 7);
+  }
+  .pb-11 {
+    padding-bottom: calc(var(--spacing) * 11);
+  }
+  .pl-1 {
+    padding-left: calc(var(--spacing) * 1);
+  }
+  .pl-2 {
+    padding-left: calc(var(--spacing) * 2);
+  }
+  .pl-2\.5 {
+    padding-left: calc(var(--spacing) * 2.5);
+  }
+  .pl-3 {
+    padding-left: calc(var(--spacing) * 3);
+  }
+  .pl-3\.5 {
+    padding-left: calc(var(--spacing) * 3.5);
+  }
+  .pl-4 {
+    padding-left: calc(var(--spacing) * 4);
+  }
+  .pl-9 {
+    padding-left: calc(var(--spacing) * 9);
+  }
+  .pl-11 {
+    padding-left: calc(var(--spacing) * 11);
+  }
+  .pl-12 {
+    padding-left: calc(var(--spacing) * 12);
+  }
+  .pl-\[34px\] {
+    padding-left: 34px;
+  }
+  .pl-\[42px\] {
+    padding-left: 42px;
+  }
+  .pl-\[62px\] {
+    padding-left: 62px;
+  }
+  .pl-\[84px\] {
+    padding-left: 84px;
+  }
+  .pl-\[90px\] {
+    padding-left: 90px;
+  }
+  .text-center {
+    text-align: center;
+  }
+  .text-left {
+    text-align: left;
+  }
+  .text-right {
+    text-align: right;
+  }
+  .text-2xl {
+    font-size: var(--text-2xl);
+    line-height: var(--tw-leading, var(--text-2xl--line-height));
+  }
+  .text-base {
+    font-size: var(--text-base);
+    line-height: var(--tw-leading, var(--text-base--line-height));
+  }
+  .text-lg {
+    font-size: var(--text-lg);
+    line-height: var(--tw-leading, var(--text-lg--line-height));
+  }
+  .text-sm {
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+  }
+  .text-theme-sm {
+    font-size: var(--text-theme-sm);
+    line-height: var(--tw-leading, var(--text-theme-sm--line-height));
+  }
+  .text-theme-xl {
+    font-size: var(--text-theme-xl);
+    line-height: var(--tw-leading, var(--text-theme-xl--line-height));
+  }
+  .text-theme-xs {
+    font-size: var(--text-theme-xs);
+    line-height: var(--tw-leading, var(--text-theme-xs--line-height));
+  }
+  .text-title-md {
+    font-size: var(--text-title-md);
+    line-height: var(--tw-leading, var(--text-title-md--line-height));
+  }
+  .text-title-sm {
+    font-size: var(--text-title-sm);
+    line-height: var(--tw-leading, var(--text-title-sm--line-height));
+  }
+  .text-xl {
+    font-size: var(--text-xl);
+    line-height: var(--tw-leading, var(--text-xl--line-height));
+  }
+  .text-xs {
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+  }
+  .leading-6 {
+    --tw-leading: calc(var(--spacing) * 6);
+    line-height: calc(var(--spacing) * 6);
+  }
+  .leading-\[20px\] {
+    --tw-leading: 20px;
+    line-height: 20px;
+  }
+  .leading-normal {
+    --tw-leading: var(--leading-normal);
+    line-height: var(--leading-normal);
+  }
+  .leading-tight {
+    --tw-leading: var(--leading-tight);
+    line-height: var(--leading-tight);
+  }
+  .font-bold {
+    --tw-font-weight: var(--font-weight-bold);
+    font-weight: var(--font-weight-bold);
+  }
+  .font-medium {
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+  }
+  .font-normal {
+    --tw-font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight-normal);
+  }
+  .font-semibold {
+    --tw-font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-semibold);
+  }
+  .-tracking-\[0\.2px\] {
+    --tw-tracking: calc(0.2px * -1);
+    letter-spacing: calc(0.2px * -1);
+  }
+  .text-blue-light-500 {
+    color: var(--color-blue-light-500);
+  }
+  .text-brand-500 {
+    color: var(--color-brand-500);
+  }
+  .text-error-500 {
+    color: var(--color-error-500);
+  }
+  .text-error-600 {
+    color: var(--color-error-600);
+  }
+  .text-error-700 {
+    color: var(--color-error-700);
+  }
+  .text-gray-300 {
+    color: var(--color-gray-300);
+  }
+  .text-gray-400 {
+    color: var(--color-gray-400);
+  }
+  .text-gray-500 {
+    color: var(--color-gray-500);
+  }
+  .text-gray-600 {
+    color: var(--color-gray-600);
+  }
+  .text-gray-700 {
+    color: var(--color-gray-700);
+  }
+  .text-gray-800 {
+    color: var(--color-gray-800);
+  }
+  .text-gray-900 {
+    color: var(--color-gray-900);
+  }
+  .text-orange-500 {
+    color: var(--color-orange-500);
+  }
+  .text-success-500 {
+    color: var(--color-success-500);
+  }
+  .text-success-600 {
+    color: var(--color-success-600);
+  }
+  .text-success-700 {
+    color: var(--color-success-700);
+  }
+  .text-theme-pink-500 {
+    color: var(--color-theme-pink-500);
+  }
+  .text-theme-purple-500 {
+    color: var(--color-theme-purple-500);
+  }
+  .text-warning-500 {
+    color: var(--color-warning-500);
+  }
+  .text-warning-600 {
+    color: var(--color-warning-600);
+  }
+  .text-warning-700 {
+    color: var(--color-warning-700);
+  }
+  .text-white {
+    color: var(--color-white);
+  }
+  .uppercase {
+    text-transform: uppercase;
+  }
+  .underline {
+    text-decoration-line: underline;
+  }
+  .opacity-0 {
+    opacity: 0%;
+  }
+  .opacity-75 {
+    opacity: 75%;
+  }
+  .shadow-sm {
+    --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+            box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-theme-lg {
+    --tw-shadow: 0px 12px 16px -4px var(--tw-shadow-color, rgba(16, 24, 40, 0.08)), 0px 4px 6px -2px var(--tw-shadow-color, rgba(16, 24, 40, 0.03));
+    -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+            box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-theme-md {
+    --tw-shadow: 0px 4px 8px -2px var(--tw-shadow-color, rgba(16, 24, 40, 0.1)), 0px 2px 4px -2px var(--tw-shadow-color, rgba(16, 24, 40, 0.06));
+    -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+            box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-theme-sm {
+    --tw-shadow: 0px 1px 3px 0px var(--tw-shadow-color, rgba(16, 24, 40, 0.1)), 0px 1px 2px 0px var(--tw-shadow-color, rgba(16, 24, 40, 0.06));
+    -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+            box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-theme-xs {
+    --tw-shadow: 0px 1px 2px 0px var(--tw-shadow-color, rgba(16, 24, 40, 0.05));
+    -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+            box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .ring-1 {
+    --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentColor);
+    -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+            box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .ring-gray-300 {
+    --tw-ring-color: var(--color-gray-300);
+  }
+  .outline-hidden {
+    outline-style: none;
+    @media (forced-colors: active) {
+      outline: 2px solid transparent;
+      outline-offset: 2px;
+    }
+  }
+  .filter {
+    -webkit-filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+            filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .backdrop-blur-\[32px\] {
+    --tw-backdrop-blur: blur(32px);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
+  .transition {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, backdrop-filter;
+    -webkit-transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+            transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    -webkit-transition-duration: var(--tw-duration, var(--default-transition-duration));
+            transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .transition-colors {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    -webkit-transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+            transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    -webkit-transition-duration: var(--tw-duration, var(--default-transition-duration));
+            transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .duration-300 {
+    --tw-duration: 300ms;
+    -webkit-transition-duration: 300ms;
+            transition-duration: 300ms;
+  }
+  .ease-in-out {
+    --tw-ease: var(--ease-in-out);
+    -webkit-transition-timing-function: var(--ease-in-out);
+            transition-timing-function: var(--ease-in-out);
+  }
+  .ease-linear {
+    --tw-ease: linear;
+    -webkit-transition-timing-function: linear;
+            transition-timing-function: linear;
+  }
+  .select-none {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+     -ms-user-select: none;
+         user-select: none;
+  }
+  .ring-inset {
+    --tw-ring-inset: inset;
+  }
+  .group-hover\:fill-gray-700 {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        fill: var(--color-gray-700);
+      }
+    }
+  }
+  .group-hover\:text-gray-400 {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        color: var(--color-gray-400);
+      }
+    }
+  }
+  .file\:mr-5 {
+    &::-webkit-file-upload-button {
+      margin-right: calc(var(--spacing) * 5);
+    }
+    &::file-selector-button {
+      margin-right: calc(var(--spacing) * 5);
+    }
+  }
+  .file\:border-collapse {
+    &::-webkit-file-upload-button {
+      border-collapse: collapse;
+    }
+    &::file-selector-button {
+      border-collapse: collapse;
+    }
+  }
+  .file\:cursor-pointer {
+    &::-webkit-file-upload-button {
+      cursor: pointer;
+    }
+    &::file-selector-button {
+      cursor: pointer;
+    }
+  }
+  .file\:rounded-l-lg {
+    &::-webkit-file-upload-button {
+      border-top-left-radius: var(--radius-lg);
+      border-bottom-left-radius: var(--radius-lg);
+    }
+    &::file-selector-button {
+      border-top-left-radius: var(--radius-lg);
+      border-bottom-left-radius: var(--radius-lg);
+    }
+  }
+  .file\:border-0 {
+    &::-webkit-file-upload-button {
+      border-style: var(--tw-border-style);
+      border-width: 0px;
+    }
+    &::file-selector-button {
+      border-style: var(--tw-border-style);
+      border-width: 0px;
+    }
+  }
+  .file\:border-r {
+    &::-webkit-file-upload-button {
+      border-right-style: var(--tw-border-style);
+      border-right-width: 1px;
+    }
+    &::file-selector-button {
+      border-right-style: var(--tw-border-style);
+      border-right-width: 1px;
+    }
+  }
+  .file\:border-solid {
+    &::-webkit-file-upload-button {
+      --tw-border-style: solid;
+      border-style: solid;
+    }
+    &::file-selector-button {
+      --tw-border-style: solid;
+      border-style: solid;
+    }
+  }
+  .file\:border-gray-200 {
+    &::-webkit-file-upload-button {
+      border-color: var(--color-gray-200);
+    }
+    &::file-selector-button {
+      border-color: var(--color-gray-200);
+    }
+  }
+  .file\:bg-gray-50 {
+    &::-webkit-file-upload-button {
+      background-color: var(--color-gray-50);
+    }
+    &::file-selector-button {
+      background-color: var(--color-gray-50);
+    }
+  }
+  .file\:py-3 {
+    &::-webkit-file-upload-button {
+      padding-block: calc(var(--spacing) * 3);
+    }
+    &::file-selector-button {
+      padding-block: calc(var(--spacing) * 3);
+    }
+  }
+  .file\:pr-3 {
+    &::-webkit-file-upload-button {
+      padding-right: calc(var(--spacing) * 3);
+    }
+    &::file-selector-button {
+      padding-right: calc(var(--spacing) * 3);
+    }
+  }
+  .file\:pl-3\.5 {
+    &::-webkit-file-upload-button {
+      padding-left: calc(var(--spacing) * 3.5);
+    }
+    &::file-selector-button {
+      padding-left: calc(var(--spacing) * 3.5);
+    }
+  }
+  .file\:text-sm {
+    &::-webkit-file-upload-button {
+      font-size: var(--text-sm);
+      line-height: var(--tw-leading, var(--text-sm--line-height));
+    }
+    &::file-selector-button {
+      font-size: var(--text-sm);
+      line-height: var(--tw-leading, var(--text-sm--line-height));
+    }
+  }
+  .file\:text-gray-700 {
+    &::-webkit-file-upload-button {
+      color: var(--color-gray-700);
+    }
+    &::file-selector-button {
+      color: var(--color-gray-700);
+    }
+  }
+  .placeholder\:text-gray-400 {
+    &::-webkit-input-placeholder {
+      color: var(--color-gray-400);
+    }
+    &::-moz-placeholder {
+      color: var(--color-gray-400);
+    }
+    &:-ms-input-placeholder {
+      color: var(--color-gray-400);
+    }
+    &::-ms-input-placeholder {
+      color: var(--color-gray-400);
+    }
+    &::placeholder {
+      color: var(--color-gray-400);
+    }
+  }
+  .placeholder\:text-gray-800 {
+    &::-webkit-input-placeholder {
+      color: var(--color-gray-800);
+    }
+    &::-moz-placeholder {
+      color: var(--color-gray-800);
+    }
+    &:-ms-input-placeholder {
+      color: var(--color-gray-800);
+    }
+    &::-ms-input-placeholder {
+      color: var(--color-gray-800);
+    }
+    &::placeholder {
+      color: var(--color-gray-800);
+    }
+  }
+  .first\:pt-0 {
+    &:first-child {
+      padding-top: calc(var(--spacing) * 0);
+    }
+  }
+  .last\:border-b-0 {
+    &:last-child {
+      border-bottom-style: var(--tw-border-style);
+      border-bottom-width: 0px;
+    }
+  }
+  .last\:pb-0 {
+    &:last-child {
+      padding-bottom: calc(var(--spacing) * 0);
+    }
+  }
+  .hover\:border-brand-500 {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-brand-500);
+      }
+    }
+  }
+  .hover\:border-brand-500\! {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-brand-500) !important;
+      }
+    }
+  }
+  .hover\:border-gray-200 {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-gray-200);
+      }
+    }
+  }
+  .hover\:bg-brand-600 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-brand-600);
+      }
+    }
+  }
+  .hover\:bg-gray-50 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-50);
+      }
+    }
+  }
+  .hover\:bg-gray-100 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-100);
+      }
+    }
+  }
+  .hover\:bg-gray-200 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-200);
+      }
+    }
+  }
+  .hover\:text-brand-600 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-brand-600);
+      }
+    }
+  }
+  .hover\:text-gray-600 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-gray-600);
+      }
+    }
+  }
+  .hover\:text-gray-700 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-gray-700);
+      }
+    }
+  }
+  .hover\:text-gray-800 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-gray-800);
+      }
+    }
+  }
+  .hover\:text-gray-900 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-gray-900);
+      }
+    }
+  }
+  .hover\:file\:bg-gray-100 {
+    &:hover {
+      @media (hover: hover) {
+        &::-webkit-file-upload-button {
+          background-color: var(--color-gray-100);
+        }
+        &::file-selector-button {
+          background-color: var(--color-gray-100);
+        }
+      }
+    }
+  }
+  .focus\:border-0 {
+    &:focus {
+      border-style: var(--tw-border-style);
+      border-width: 0px;
+    }
+  }
+  .focus\:border-brand-300 {
+    &:focus {
+      border-color: var(--color-brand-300);
+    }
+  }
+  .focus\:border-error-300 {
+    &:focus {
+      border-color: var(--color-error-300);
+    }
+  }
+  .focus\:border-success-300 {
+    &:focus {
+      border-color: var(--color-success-300);
+    }
+  }
+  .focus\:shadow-focus-ring {
+    &:focus {
+      --tw-shadow: 0px 0px 0px 4px var(--tw-shadow-color, rgba(70, 95, 255, 0.12));
+      -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+              box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus\:ring-0 {
+    &:focus {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentColor);
+      -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+              box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus\:ring-3 {
+    &:focus {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentColor);
+      -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+              box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus\:ring-brand-500\/10 {
+    &:focus {
+      --tw-ring-color: color-mix(in oklab, var(--color-brand-500) 10%, transparent);
+    }
+  }
+  .focus\:ring-error-500\/10 {
+    &:focus {
+      --tw-ring-color: color-mix(in oklab, var(--color-error-500) 10%, transparent);
+    }
+  }
+  .focus\:ring-success-500\/10 {
+    &:focus {
+      --tw-ring-color: color-mix(in oklab, var(--color-success-500) 10%, transparent);
+    }
+  }
+  .focus\:outline-hidden {
+    &:focus {
+      outline-style: none;
+      @media (forced-colors: active) {
+        outline: 2px solid transparent;
+        outline-offset: 2px;
+      }
+    }
+  }
+  .focus\:file\:ring-brand-300 {
+    &:focus {
+      &::-webkit-file-upload-button {
+        --tw-ring-color: var(--color-brand-300);
+      }
+      &::file-selector-button {
+        --tw-ring-color: var(--color-brand-300);
+      }
+    }
+  }
+  .focus-visible\:outline-hidden {
+    &:focus-visible {
+      outline-style: none;
+      @media (forced-colors: active) {
+        outline: 2px solid transparent;
+        outline-offset: 2px;
+      }
+    }
+  }
+  .disabled\:border-gray-100 {
+    &:disabled {
+      border-color: var(--color-gray-100);
+    }
+  }
+  .disabled\:bg-gray-50 {
+    &:disabled {
+      background-color: var(--color-gray-50);
+    }
+  }
+  .disabled\:placeholder\:text-gray-300 {
+    &:disabled {
+      &::-webkit-input-placeholder {
+        color: var(--color-gray-300);
+      }
+      &::-moz-placeholder {
+        color: var(--color-gray-300);
+      }
+      &:-ms-input-placeholder {
+        color: var(--color-gray-300);
+      }
+      &::-ms-input-placeholder {
+        color: var(--color-gray-300);
+      }
+      &::placeholder {
+        color: var(--color-gray-300);
+      }
+    }
+  }
+  .\32 xsm\:w-\[307px\] {
+    @media (width >= 375px) {
+      width: 307px;
+    }
+  }
+  .\32 xsm\:gap-3 {
+    @media (width >= 375px) {
+      gap: calc(var(--spacing) * 3);
+    }
+  }
+  .xsm\:w-\[358px\] {
+    @media (width >= 425px) {
+      width: 358px;
+    }
+  }
+  .sm\:col-span-1 {
+    @media (width >= 640px) {
+      grid-column: span 1 / span 1;
+    }
+  }
+  .sm\:-mx-6 {
+    @media (width >= 640px) {
+      margin-inline: calc(var(--spacing) * -6);
+    }
+  }
+  .sm\:mb-8 {
+    @media (width >= 640px) {
+      margin-bottom: calc(var(--spacing) * 8);
+    }
+  }
+  .sm\:block {
+    @media (width >= 640px) {
+      display: block;
+    }
+  }
+  .sm\:h-11 {
+    @media (width >= 640px) {
+      height: calc(var(--spacing) * 11);
+    }
+  }
+  .sm\:w-11 {
+    @media (width >= 640px) {
+      width: calc(var(--spacing) * 11);
+    }
+  }
+  .sm\:w-\[361px\] {
+    @media (width >= 640px) {
+      width: 361px;
+    }
+  }
+  .sm\:w-auto {
+    @media (width >= 640px) {
+      width: auto;
+    }
+  }
+  .sm\:max-w-\[472px\] {
+    @media (width >= 640px) {
+      max-width: 472px;
+    }
+  }
+  .sm\:grid-cols-2 {
+    @media (width >= 640px) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .sm\:flex-row {
+    @media (width >= 640px) {
+      -webkit-box-orient: horizontal;
+      -webkit-box-direction: normal;
+          -ms-flex-direction: row;
+              flex-direction: row;
+    }
+  }
+  .sm\:items-center {
+    @media (width >= 640px) {
+      -webkit-box-align: center;
+          -ms-flex-align: center;
+              align-items: center;
+    }
+  }
+  .sm\:justify-between {
+    @media (width >= 640px) {
+      -webkit-box-pack: justify;
+          -ms-flex-pack: justify;
+              justify-content: space-between;
+    }
+  }
+  .sm\:justify-center {
+    @media (width >= 640px) {
+      -webkit-box-pack: center;
+          -ms-flex-pack: center;
+              justify-content: center;
+    }
+  }
+  .sm\:justify-end {
+    @media (width >= 640px) {
+      -webkit-box-pack: end;
+          -ms-flex-pack: end;
+              justify-content: flex-end;
+    }
+  }
+  .sm\:gap-4 {
+    @media (width >= 640px) {
+      gap: calc(var(--spacing) * 4);
+    }
+  }
+  .sm\:gap-5 {
+    @media (width >= 640px) {
+      gap: calc(var(--spacing) * 5);
+    }
+  }
+  .sm\:gap-6 {
+    @media (width >= 640px) {
+      gap: calc(var(--spacing) * 6);
+    }
+  }
+  .sm\:gap-8 {
+    @media (width >= 640px) {
+      gap: calc(var(--spacing) * 8);
+    }
+  }
+  .sm\:space-y-6 {
+    @media (width >= 640px) {
+      :where(& > :not(:last-child)) {
+        --tw-space-y-reverse: 0;
+        -webkit-margin-before: calc(calc(var(--spacing) * 6) * var(--tw-space-y-reverse));
+                margin-block-start: calc(calc(var(--spacing) * 6) * var(--tw-space-y-reverse));
+        -webkit-margin-after: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-y-reverse)));
+                margin-block-end: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-y-reverse)));
+      }
+    }
+  }
+  .sm\:p-0 {
+    @media (width >= 640px) {
+      padding: calc(var(--spacing) * 0);
+    }
+  }
+  .sm\:p-6 {
+    @media (width >= 640px) {
+      padding: calc(var(--spacing) * 6);
+    }
+  }
+  .sm\:px-5 {
+    @media (width >= 640px) {
+      padding-inline: calc(var(--spacing) * 5);
+    }
+  }
+  .sm\:px-6 {
+    @media (width >= 640px) {
+      padding-inline: calc(var(--spacing) * 6);
+    }
+  }
+  .sm\:py-2 {
+    @media (width >= 640px) {
+      padding-block: calc(var(--spacing) * 2);
+    }
+  }
+  .sm\:py-5 {
+    @media (width >= 640px) {
+      padding-block: calc(var(--spacing) * 5);
+    }
+  }
+  .sm\:py-10 {
+    @media (width >= 640px) {
+      padding-block: calc(var(--spacing) * 10);
+    }
+  }
+  .sm\:pt-6 {
+    @media (width >= 640px) {
+      padding-top: calc(var(--spacing) * 6);
+    }
+  }
+  .sm\:pr-4 {
+    @media (width >= 640px) {
+      padding-right: calc(var(--spacing) * 4);
+    }
+  }
+  .sm\:pl-6 {
+    @media (width >= 640px) {
+      padding-left: calc(var(--spacing) * 6);
+    }
+  }
+  .sm\:text-start {
+    @media (width >= 640px) {
+      text-align: start;
+    }
+  }
+  .sm\:text-2xl {
+    @media (width >= 640px) {
+      font-size: var(--text-2xl);
+      line-height: var(--tw-leading, var(--text-2xl--line-height));
+    }
+  }
+  .sm\:text-base {
+    @media (width >= 640px) {
+      font-size: var(--text-base);
+      line-height: var(--tw-leading, var(--text-base--line-height));
+    }
+  }
+  .sm\:text-lg {
+    @media (width >= 640px) {
+      font-size: var(--text-lg);
+      line-height: var(--tw-leading, var(--text-lg--line-height));
+    }
+  }
+  .sm\:text-sm {
+    @media (width >= 640px) {
+      font-size: var(--text-sm);
+      line-height: var(--tw-leading, var(--text-sm--line-height));
+    }
+  }
+  .sm\:text-title-md {
+    @media (width >= 640px) {
+      font-size: var(--text-title-md);
+      line-height: var(--tw-leading, var(--text-title-md--line-height));
+    }
+  }
+  .md\:w-\[668px\] {
+    @media (width >= 768px) {
+      width: 668px;
+    }
+  }
+  .md\:gap-6 {
+    @media (width >= 768px) {
+      gap: calc(var(--spacing) * 6);
+    }
+  }
+  .md\:p-6 {
+    @media (width >= 768px) {
+      padding: calc(var(--spacing) * 6);
+    }
+  }
+  .lg\:static {
+    @media (width >= 1024px) {
+      position: static;
+    }
+  }
+  .lg\:right-0 {
+    @media (width >= 1024px) {
+      right: calc(var(--spacing) * 0);
+    }
+  }
+  .lg\:col-span-1 {
+    @media (width >= 1024px) {
+      grid-column: span 1 / span 1;
+    }
+  }
+  .lg\:mb-6 {
+    @media (width >= 1024px) {
+      margin-bottom: calc(var(--spacing) * 6);
+    }
+  }
+  .lg\:mb-7 {
+    @media (width >= 1024px) {
+      margin-bottom: calc(var(--spacing) * 7);
+    }
+  }
+  .lg\:block {
+    @media (width >= 1024px) {
+      display: block;
+    }
+  }
+  .lg\:flex {
+    @media (width >= 1024px) {
+      display: -webkit-box;
+      display: -ms-flexbox;
+      display: flex;
+    }
+  }
+  .lg\:grid {
+    @media (width >= 1024px) {
+      display: grid;
+    }
+  }
+  .lg\:hidden {
+    @media (width >= 1024px) {
+      display: none;
+    }
+  }
+  .lg\:inline-flex {
+    @media (width >= 1024px) {
+      display: -webkit-inline-box;
+      display: -ms-inline-flexbox;
+      display: inline-flex;
+    }
+  }
+  .lg\:h-11 {
+    @media (width >= 1024px) {
+      height: calc(var(--spacing) * 11);
+    }
+  }
+  .lg\:w-1\/2 {
+    @media (width >= 1024px) {
+      width: calc(1/2 * 100%);
+    }
+  }
+  .lg\:w-11 {
+    @media (width >= 1024px) {
+      width: calc(var(--spacing) * 11);
+    }
+  }
+  .lg\:w-\[90px\] {
+    @media (width >= 1024px) {
+      width: 90px;
+    }
+  }
+  .lg\:w-\[634px\] {
+    @media (width >= 1024px) {
+      width: 634px;
+    }
+  }
+  .lg\:w-auto {
+    @media (width >= 1024px) {
+      width: auto;
+    }
+  }
+  .lg\:translate-x-0 {
+    @media (width >= 1024px) {
+      --tw-translate-x: calc(var(--spacing) * 0);
+      translate: var(--tw-translate-x) var(--tw-translate-y);
+    }
+  }
+  .lg\:grid-cols-2 {
+    @media (width >= 1024px) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .lg\:flex-row {
+    @media (width >= 1024px) {
+      -webkit-box-orient: horizontal;
+      -webkit-box-direction: normal;
+          -ms-flex-direction: row;
+              flex-direction: row;
+    }
+  }
+  .lg\:items-start {
+    @media (width >= 1024px) {
+      -webkit-box-align: start;
+          -ms-flex-align: start;
+              align-items: flex-start;
+    }
+  }
+  .lg\:justify-between {
+    @media (width >= 1024px) {
+      -webkit-box-pack: justify;
+          -ms-flex-pack: justify;
+              justify-content: space-between;
+    }
+  }
+  .lg\:justify-end {
+    @media (width >= 1024px) {
+      -webkit-box-pack: end;
+          -ms-flex-pack: end;
+              justify-content: flex-end;
+    }
+  }
+  .lg\:justify-normal {
+    @media (width >= 1024px) {
+      -webkit-box-pack: normal;
+          -ms-flex-pack: normal;
+              justify-content: normal;
+    }
+  }
+  .lg\:gap-7 {
+    @media (width >= 1024px) {
+      gap: calc(var(--spacing) * 7);
+    }
+  }
+  .lg\:border {
+    @media (width >= 1024px) {
+      border-style: var(--tw-border-style);
+      border-width: 1px;
+    }
+  }
+  .lg\:border-b {
+    @media (width >= 1024px) {
+      border-bottom-style: var(--tw-border-style);
+      border-bottom-width: 1px;
+    }
+  }
+  .lg\:border-b-0 {
+    @media (width >= 1024px) {
+      border-bottom-style: var(--tw-border-style);
+      border-bottom-width: 0px;
+    }
+  }
+  .lg\:bg-transparent {
+    @media (width >= 1024px) {
+      background-color: transparent;
+    }
+  }
+  .lg\:p-6 {
+    @media (width >= 1024px) {
+      padding: calc(var(--spacing) * 6);
+    }
+  }
+  .lg\:p-10 {
+    @media (width >= 1024px) {
+      padding: calc(var(--spacing) * 10);
+    }
+  }
+  .lg\:p-11 {
+    @media (width >= 1024px) {
+      padding: calc(var(--spacing) * 11);
+    }
+  }
+  .lg\:px-0 {
+    @media (width >= 1024px) {
+      padding-inline: calc(var(--spacing) * 0);
+    }
+  }
+  .lg\:px-6 {
+    @media (width >= 1024px) {
+      padding-inline: calc(var(--spacing) * 6);
+    }
+  }
+  .lg\:py-4 {
+    @media (width >= 1024px) {
+      padding-block: calc(var(--spacing) * 4);
+    }
+  }
+  .lg\:py-\[120px\] {
+    @media (width >= 1024px) {
+      padding-block: 120px;
+    }
+  }
+  .lg\:text-2xl {
+    @media (width >= 1024px) {
+      font-size: var(--text-2xl);
+      line-height: var(--tw-leading, var(--text-2xl--line-height));
+    }
+  }
+  .lg\:shadow-none {
+    @media (width >= 1024px) {
+      --tw-shadow: 0 0 #0000;
+      -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+              box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .xl\:order-2 {
+    @media (width >= 1280px) {
+      -webkit-box-ordinal-group: 3;
+          -ms-flex-order: 2;
+              order: 2;
+    }
+  }
+  .xl\:order-3 {
+    @media (width >= 1280px) {
+      -webkit-box-ordinal-group: 4;
+          -ms-flex-order: 3;
+              order: 3;
+    }
+  }
+  .xl\:col-span-5 {
+    @media (width >= 1280px) {
+      grid-column: span 5 / span 5;
+    }
+  }
+  .xl\:col-span-7 {
+    @media (width >= 1280px) {
+      grid-column: span 7 / span 7;
+    }
+  }
+  .xl\:block {
+    @media (width >= 1280px) {
+      display: block;
+    }
+  }
+  .xl\:w-\[300px\] {
+    @media (width >= 1280px) {
+      width: 300px;
+    }
+  }
+  .xl\:w-\[393px\] {
+    @media (width >= 1280px) {
+      width: 393px;
+    }
+  }
+  .xl\:w-\[430px\] {
+    @media (width >= 1280px) {
+      width: 430px;
+    }
+  }
+  .xl\:max-w-\[450px\] {
+    @media (width >= 1280px) {
+      max-width: 450px;
+    }
+  }
+  .xl\:max-w-fit {
+    @media (width >= 1280px) {
+      max-width: -webkit-fit-content;
+      max-width: -moz-fit-content;
+      max-width: fit-content;
+    }
+  }
+  .xl\:min-w-full {
+    @media (width >= 1280px) {
+      min-width: 100%;
+    }
+  }
+  .xl\:grid-cols-2 {
+    @media (width >= 1280px) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .xl\:grid-cols-3 {
+    @media (width >= 1280px) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+  .xl\:flex-row {
+    @media (width >= 1280px) {
+      -webkit-box-orient: horizontal;
+      -webkit-box-direction: normal;
+          -ms-flex-direction: row;
+              flex-direction: row;
+    }
+  }
+  .xl\:items-center {
+    @media (width >= 1280px) {
+      -webkit-box-align: center;
+          -ms-flex-align: center;
+              align-items: center;
+    }
+  }
+  .xl\:justify-between {
+    @media (width >= 1280px) {
+      -webkit-box-pack: justify;
+          -ms-flex-pack: justify;
+              justify-content: space-between;
+    }
+  }
+  .xl\:justify-end {
+    @media (width >= 1280px) {
+      -webkit-box-pack: end;
+          -ms-flex-pack: end;
+              justify-content: flex-end;
+    }
+  }
+  .xl\:gap-3 {
+    @media (width >= 1280px) {
+      gap: calc(var(--spacing) * 3);
+    }
+  }
+  .xl\:p-10 {
+    @media (width >= 1280px) {
+      padding: calc(var(--spacing) * 10);
+    }
+  }
+  .xl\:px-10 {
+    @media (width >= 1280px) {
+      padding-inline: calc(var(--spacing) * 10);
+    }
+  }
+  .xl\:py-12 {
+    @media (width >= 1280px) {
+      padding-block: calc(var(--spacing) * 12);
+    }
+  }
+  .xl\:pr-5 {
+    @media (width >= 1280px) {
+      padding-right: calc(var(--spacing) * 5);
+    }
+  }
+  .xl\:pl-11 {
+    @media (width >= 1280px) {
+      padding-left: calc(var(--spacing) * 11);
+    }
+  }
+  .xl\:text-left {
+    @media (width >= 1280px) {
+      text-align: left;
+    }
+  }
+  .xl\:text-title-2xl {
+    @media (width >= 1280px) {
+      font-size: var(--text-title-2xl);
+      line-height: var(--tw-leading, var(--text-title-2xl--line-height));
+    }
+  }
+  .\32 xl\:w-\[554px\] {
+    @media (width >= 1536px) {
+      width: 554px;
+    }
+  }
+  .\32 xl\:gap-x-32 {
+    @media (width >= 1536px) {
+      -webkit-column-gap: calc(var(--spacing) * 32);
+         -moz-column-gap: calc(var(--spacing) * 32);
+              column-gap: calc(var(--spacing) * 32);
+    }
+  }
+  .dark\:block {
+    &:is(.dark *) {
+      display: block;
+    }
+  }
+  .dark\:hidden {
+    &:is(.dark *) {
+      display: none;
+    }
+  }
+  .dark\:divide-gray-800 {
+    &:is(.dark *) {
+      :where(& > :not(:last-child)) {
+        border-color: var(--color-gray-800);
+      }
+    }
+  }
+  .dark\:border-blue-light-500\/30 {
+    &:is(.dark *) {
+      border-color: color-mix(in oklab, var(--color-blue-light-500) 30%, transparent);
+    }
+  }
+  .dark\:border-brand-500 {
+    &:is(.dark *) {
+      border-color: var(--color-brand-500);
+    }
+  }
+  .dark\:border-error-500\/30 {
+    &:is(.dark *) {
+      border-color: color-mix(in oklab, var(--color-error-500) 30%, transparent);
+    }
+  }
+  .dark\:border-error-700 {
+    &:is(.dark *) {
+      border-color: var(--color-error-700);
+    }
+  }
+  .dark\:border-gray-700 {
+    &:is(.dark *) {
+      border-color: var(--color-gray-700);
+    }
+  }
+  .dark\:border-gray-700\! {
+    &:is(.dark *) {
+      border-color: var(--color-gray-700) !important;
+    }
+  }
+  .dark\:border-gray-800 {
+    &:is(.dark *) {
+      border-color: var(--color-gray-800);
+    }
+  }
+  .dark\:border-gray-900 {
+    &:is(.dark *) {
+      border-color: var(--color-gray-900);
+    }
+  }
+  .dark\:border-success-500\/30 {
+    &:is(.dark *) {
+      border-color: color-mix(in oklab, var(--color-success-500) 30%, transparent);
+    }
+  }
+  .dark\:border-success-700 {
+    &:is(.dark *) {
+      border-color: var(--color-success-700);
+    }
+  }
+  .dark\:border-warning-500\/30 {
+    &:is(.dark *) {
+      border-color: color-mix(in oklab, var(--color-warning-500) 30%, transparent);
+    }
+  }
+  .dark\:bg-\[\#171f2e\] {
+    &:is(.dark *) {
+      background-color: #171f2e;
+    }
+  }
+  .dark\:bg-black {
+    &:is(.dark *) {
+      background-color: var(--color-black);
+    }
+  }
+  .dark\:bg-blue-light-500\/15 {
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-blue-light-500) 15%, transparent);
+    }
+  }
+  .dark\:bg-brand-500 {
+    &:is(.dark *) {
+      background-color: var(--color-brand-500);
+    }
+  }
+  .dark\:bg-brand-500\/15 {
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-brand-500) 15%, transparent);
+    }
+  }
+  .dark\:bg-error-500\/15 {
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-error-500) 15%, transparent);
+    }
+  }
+  .dark\:bg-gray-700 {
+    &:is(.dark *) {
+      background-color: var(--color-gray-700);
+    }
+  }
+  .dark\:bg-gray-800 {
+    &:is(.dark *) {
+      background-color: var(--color-gray-800);
+    }
+  }
+  .dark\:bg-gray-900 {
+    &:is(.dark *) {
+      background-color: var(--color-gray-900);
+    }
+  }
+  .dark\:bg-gray-dark {
+    &:is(.dark *) {
+      background-color: var(--color-gray-dark);
+    }
+  }
+  .dark\:bg-success-500\/15 {
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-success-500) 15%, transparent);
+    }
+  }
+  .dark\:bg-transparent {
+    &:is(.dark *) {
+      background-color: transparent;
+    }
+  }
+  .dark\:bg-warning-500\/15 {
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-warning-500) 15%, transparent);
+    }
+  }
+  .dark\:bg-white\/0 {
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-white) 0%, transparent);
+    }
+  }
+  .dark\:bg-white\/5 {
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-white) 5%, transparent);
+    }
+  }
+  .dark\:bg-white\/10 {
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-white) 10%, transparent);
+    }
+  }
+  .dark\:bg-white\/15 {
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-white) 15%, transparent);
+    }
+  }
+  .dark\:bg-white\/\[0\.03\] {
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-white) 3%, transparent);
+    }
+  }
+  .dark\:bg-white\/\[0\.05\] {
+    &:is(.dark *) {
+      background-color: color-mix(in oklab, var(--color-white) 5%, transparent);
+    }
+  }
+  .dark\:fill-gray-400 {
+    &:is(.dark *) {
+      fill: var(--color-gray-400);
+    }
+  }
+  .dark\:fill-gray-800 {
+    &:is(.dark *) {
+      fill: var(--color-gray-800);
+    }
+  }
+  .dark\:fill-white\/90 {
+    &:is(.dark *) {
+      fill: color-mix(in oklab, var(--color-white) 90%, transparent);
+    }
+  }
+  .dark\:stroke-gray-400 {
+    &:is(.dark *) {
+      stroke: var(--color-gray-400);
+    }
+  }
+  .dark\:stroke-gray-800 {
+    &:is(.dark *) {
+      stroke: var(--color-gray-800);
+    }
+  }
+  .dark\:text-blue-light-500 {
+    &:is(.dark *) {
+      color: var(--color-blue-light-500);
+    }
+  }
+  .dark\:text-brand-400 {
+    &:is(.dark *) {
+      color: var(--color-brand-400);
+    }
+  }
+  .dark\:text-error-500 {
+    &:is(.dark *) {
+      color: var(--color-error-500);
+    }
+  }
+  .dark\:text-gray-400 {
+    &:is(.dark *) {
+      color: var(--color-gray-400);
+    }
+  }
+  .dark\:text-gray-700 {
+    &:is(.dark *) {
+      color: var(--color-gray-700);
+    }
+  }
+  .dark\:text-orange-400 {
+    &:is(.dark *) {
+      color: var(--color-orange-400);
+    }
+  }
+  .dark\:text-success-500 {
+    &:is(.dark *) {
+      color: var(--color-success-500);
+    }
+  }
+  .dark\:text-warning-400 {
+    &:is(.dark *) {
+      color: var(--color-warning-400);
+    }
+  }
+  .dark\:text-white {
+    &:is(.dark *) {
+      color: var(--color-white);
+    }
+  }
+  .dark\:text-white\/15 {
+    &:is(.dark *) {
+      color: color-mix(in oklab, var(--color-white) 15%, transparent);
+    }
+  }
+  .dark\:text-white\/60 {
+    &:is(.dark *) {
+      color: color-mix(in oklab, var(--color-white) 60%, transparent);
+    }
+  }
+  .dark\:text-white\/80 {
+    &:is(.dark *) {
+      color: color-mix(in oklab, var(--color-white) 80%, transparent);
+    }
+  }
+  .dark\:text-white\/90 {
+    &:is(.dark *) {
+      color: color-mix(in oklab, var(--color-white) 90%, transparent);
+    }
+  }
+  .dark\:ring-gray-700 {
+    &:is(.dark *) {
+      --tw-ring-color: var(--color-gray-700);
+    }
+  }
+  .dark\:group-hover\:fill-gray-300 {
+    &:is(.dark *) {
+      &:is(:where(.group):hover *) {
+        @media (hover: hover) {
+          fill: var(--color-gray-300);
+        }
+      }
+    }
+  }
+  .dark\:file\:border-gray-800 {
+    &:is(.dark *) {
+      &::-webkit-file-upload-button {
+        border-color: var(--color-gray-800);
+      }
+      &::file-selector-button {
+        border-color: var(--color-gray-800);
+      }
+    }
+  }
+  .dark\:file\:bg-white\/\[0\.03\] {
+    &:is(.dark *) {
+      &::-webkit-file-upload-button {
+        background-color: color-mix(in oklab, var(--color-white) 3%, transparent);
+      }
+      &::file-selector-button {
+        background-color: color-mix(in oklab, var(--color-white) 3%, transparent);
+      }
+    }
+  }
+  .dark\:file\:text-gray-400 {
+    &:is(.dark *) {
+      &::-webkit-file-upload-button {
+        color: var(--color-gray-400);
+      }
+      &::file-selector-button {
+        color: var(--color-gray-400);
+      }
+    }
+  }
+  .dark\:placeholder\:text-gray-400 {
+    &:is(.dark *) {
+      &::-webkit-input-placeholder {
+        color: var(--color-gray-400);
+      }
+      &::-moz-placeholder {
+        color: var(--color-gray-400);
+      }
+      &:-ms-input-placeholder {
+        color: var(--color-gray-400);
+      }
+      &::-ms-input-placeholder {
+        color: var(--color-gray-400);
+      }
+      &::placeholder {
+        color: var(--color-gray-400);
+      }
+    }
+  }
+  .dark\:placeholder\:text-white\/30 {
+    &:is(.dark *) {
+      &::-webkit-input-placeholder {
+        color: color-mix(in oklab, var(--color-white) 30%, transparent);
+      }
+      &::-moz-placeholder {
+        color: color-mix(in oklab, var(--color-white) 30%, transparent);
+      }
+      &:-ms-input-placeholder {
+        color: color-mix(in oklab, var(--color-white) 30%, transparent);
+      }
+      &::-ms-input-placeholder {
+        color: color-mix(in oklab, var(--color-white) 30%, transparent);
+      }
+      &::placeholder {
+        color: color-mix(in oklab, var(--color-white) 30%, transparent);
+      }
+    }
+  }
+  .dark\:placeholder\:text-white\/90 {
+    &:is(.dark *) {
+      &::-webkit-input-placeholder {
+        color: color-mix(in oklab, var(--color-white) 90%, transparent);
+      }
+      &::-moz-placeholder {
+        color: color-mix(in oklab, var(--color-white) 90%, transparent);
+      }
+      &:-ms-input-placeholder {
+        color: color-mix(in oklab, var(--color-white) 90%, transparent);
+      }
+      &::-ms-input-placeholder {
+        color: color-mix(in oklab, var(--color-white) 90%, transparent);
+      }
+      &::placeholder {
+        color: color-mix(in oklab, var(--color-white) 90%, transparent);
+      }
+    }
+  }
+  .dark\:hover\:border-brand-500 {
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          border-color: var(--color-brand-500);
+        }
+      }
+    }
+  }
+  .dark\:hover\:border-brand-500\! {
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          border-color: var(--color-brand-500) !important;
+        }
+      }
+    }
+  }
+  .dark\:hover\:border-gray-800 {
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          border-color: var(--color-gray-800);
+        }
+      }
+    }
+  }
+  .dark\:hover\:bg-gray-800 {
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: var(--color-gray-800);
+        }
+      }
+    }
+  }
+  .dark\:hover\:bg-white\/5 {
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: color-mix(in oklab, var(--color-white) 5%, transparent);
+        }
+      }
+    }
+  }
+  .dark\:hover\:bg-white\/10 {
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: color-mix(in oklab, var(--color-white) 10%, transparent);
+        }
+      }
+    }
+  }
+  .dark\:hover\:bg-white\/\[0\.03\] {
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: color-mix(in oklab, var(--color-white) 3%, transparent);
+        }
+      }
+    }
+  }
+  .dark\:hover\:bg-white\/\[0\.07\] {
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: color-mix(in oklab, var(--color-white) 7.000000000000001%, transparent);
+        }
+      }
+    }
+  }
+  .dark\:hover\:text-gray-200 {
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          color: var(--color-gray-200);
+        }
+      }
+    }
+  }
+  .dark\:hover\:text-gray-300 {
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          color: var(--color-gray-300);
+        }
+      }
+    }
+  }
+  .dark\:hover\:text-white {
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          color: var(--color-white);
+        }
+      }
+    }
+  }
+  .dark\:hover\:text-white\/90 {
+    &:is(.dark *) {
+      &:hover {
+        @media (hover: hover) {
+          color: color-mix(in oklab, var(--color-white) 90%, transparent);
+        }
+      }
+    }
+  }
+  .dark\:focus\:border-brand-300 {
+    &:is(.dark *) {
+      &:focus {
+        border-color: var(--color-brand-300);
+      }
+    }
+  }
+  .dark\:focus\:border-brand-800 {
+    &:is(.dark *) {
+      &:focus {
+        border-color: var(--color-brand-800);
+      }
+    }
+  }
+  .dark\:focus\:border-error-800 {
+    &:is(.dark *) {
+      &:focus {
+        border-color: var(--color-error-800);
+      }
+    }
+  }
+  .dark\:focus\:border-success-800 {
+    &:is(.dark *) {
+      &:focus {
+        border-color: var(--color-success-800);
+      }
+    }
+  }
+  .dark\:disabled\:border-gray-800 {
+    &:is(.dark *) {
+      &:disabled {
+        border-color: var(--color-gray-800);
+      }
+    }
+  }
+  .dark\:disabled\:bg-white\/\[0\.03\] {
+    &:is(.dark *) {
+      &:disabled {
+        background-color: color-mix(in oklab, var(--color-white) 3%, transparent);
+      }
+    }
+  }
+  .dark\:disabled\:placeholder\:text-white\/15 {
+    &:is(.dark *) {
+      &:disabled {
+        &::-webkit-input-placeholder {
+          color: color-mix(in oklab, var(--color-white) 15%, transparent);
+        }
+        &::-moz-placeholder {
+          color: color-mix(in oklab, var(--color-white) 15%, transparent);
+        }
+        &:-ms-input-placeholder {
+          color: color-mix(in oklab, var(--color-white) 15%, transparent);
+        }
+        &::-ms-input-placeholder {
+          color: color-mix(in oklab, var(--color-white) 15%, transparent);
+        }
+        &::placeholder {
+          color: color-mix(in oklab, var(--color-white) 15%, transparent);
+        }
+      }
+    }
+  }
+  .dark\:lg\:bg-transparent {
+    &:is(.dark *) {
+      @media (width >= 1024px) {
+        background-color: transparent;
+      }
+    }
+  }
+}
+@layer base {
+  ::-ms-backdrop {
+    border-color: var(--color-gray-200, currentColor);
+  }
+  ::-webkit-file-upload-button {
+    border-color: var(--color-gray-200, currentColor);
+  }
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-gray-200, currentColor);
+  }
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}
+.dark .custom-scrollbar::-webkit-scrollbar-thumb {
+  background-color: #344054;
+}
+@layer base {
+  body {
+    position: relative;
+    z-index: var(--z-index-1);
+    background-color: var(--color-gray-50);
+    font-family: var(--font-outfit);
+    font-size: var(--text-base);
+    line-height: var(--tw-leading, var(--text-base--line-height));
+    --tw-font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight-normal);
+  }
+}
+@layer utilities {
+  input[type="date"]::-webkit-inner-spin-button,
+  input[type="time"]::-webkit-inner-spin-button,
+  input[type="date"]::-webkit-calendar-picker-indicator,
+  input[type="time"]::-webkit-calendar-picker-indicator {
+    display: none;
+    -webkit-appearance: none;
+  }
+}
+.sidebar:hover {
+  width: 290px;
+}
+.sidebar:hover .logo {
+  display: block;
+}
+.sidebar:hover .logo-icon {
+  display: none;
+}
+.sidebar:hover .sidebar-header {
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+}
+.sidebar:hover .menu-group-title {
+  display: block;
+}
+.sidebar:hover .menu-group-icon {
+  display: none;
+}
+.sidebar:hover .menu-item-text {
+  display: inline;
+}
+.sidebar:hover .menu-item-arrow {
+  display: block;
+}
+.sidebar:hover .menu-dropdown {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+.tableCheckbox:checked ~ span span {
+  opacity: 100%;
+}
+.tableCheckbox:checked ~ span {
+  border-color: var(--color-brand-500);
+  background-color: var(--color-brand-500);
+}
+.apexcharts-legend-text {
+  color: var(--color-gray-700) !important;
+  &:is(.dark *) {
+    color: var(--color-gray-400) !important;
+  }
+}
+.apexcharts-text {
+  fill: var(--color-gray-700) !important;
+  &:is(.dark *) {
+    fill: var(--color-gray-400) !important;
+  }
+}
+.apexcharts-tooltip.apexcharts-theme-light {
+  gap: calc(var(--spacing) * 1);
+  border-radius: var(--radius-lg) !important;
+  border-color: var(--color-gray-200) !important;
+  padding: calc(var(--spacing) * 3);
+  --tw-shadow: 0px 1px 3px 0px var(--tw-shadow-color, rgba(16, 24, 40, 0.1)), 0px 1px 2px 0px var(--tw-shadow-color, rgba(16, 24, 40, 0.06));
+  -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+          box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+  &:is(.dark *) {
+    border-color: var(--color-gray-800) !important;
+  }
+  &:is(.dark *) {
+    background-color: var(--color-gray-900) !important;
+  }
+}
+.apexcharts-tooltip-marker {
+  margin-right: calc(var(--spacing) * 1.5) !important;
+  height: calc(var(--spacing) * 1.5) !important;
+  width: calc(var(--spacing) * 1.5) !important;
+}
+.apexcharts-legend-text {
+  padding-left: calc(var(--spacing) * 5) !important;
+  color: var(--color-gray-700) !important;
+  &:is(.dark *) {
+    color: var(--color-gray-400) !important;
+  }
+}
+.apexcharts-tooltip-series-group {
+  padding: calc(var(--spacing) * 0) !important;
+}
+.apexcharts-tooltip-y-group {
+  padding: calc(var(--spacing) * 0) !important;
+}
+.apexcharts-tooltip-title {
+  margin-bottom: calc(var(--spacing) * 0) !important;
+  border-bottom-style: var(--tw-border-style) !important;
+  border-bottom-width: 0px !important;
+  background-color: transparent !important;
+  padding: calc(var(--spacing) * 0) !important;
+  font-size: 10px !important;
+  --tw-leading: calc(var(--spacing) * 4);
+  line-height: calc(var(--spacing) * 4) !important;
+  color: var(--color-gray-800) !important;
+  &:is(.dark *) {
+    color: color-mix(in oklab, var(--color-white) 90%, transparent) !important;
+  }
+}
+.apexcharts-tooltip-text {
+  font-size: var(--text-theme-xs) !important;
+  line-height: var(--tw-leading, var(--text-theme-xs--line-height)) !important;
+  color: var(--color-gray-700) !important;
+  &:is(.dark *) {
+    color: color-mix(in oklab, var(--color-white) 90%, transparent) !important;
+  }
+}
+.apexcharts-tooltip-text-y-value {
+  --tw-font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-medium) !important;
+}
+.apexcharts-gridline {
+  stroke: var(--color-gray-100) !important;
+  &:is(.dark *) {
+    stroke: var(--color-gray-800) !important;
+  }
+}
+#chartTwo .apexcharts-datalabels-group {
+  --tw-translate-y: calc(var(--spacing) * -24);
+  translate: var(--tw-translate-x) var(--tw-translate-y) !important;
+}
+#chartTwo .apexcharts-datalabels-group .apexcharts-text {
+  fill: var(--color-gray-800) !important;
+  --tw-font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-semibold) !important;
+  &:is(.dark *) {
+    fill: color-mix(in oklab, var(--color-white) 90%, transparent) !important;
+  }
+}
+#chartSixteen .apexcharts-legend {
+  padding: calc(var(--spacing) * 0) !important;
+  padding-left: calc(var(--spacing) * 6) !important;
+}
+.jvm-container {
+  background-color: var(--color-gray-50) !important;
+  &:is(.dark *) {
+    background-color: var(--color-gray-900) !important;
+  }
+}
+.jvm-region.jvm-element {
+  fill: var(--color-gray-300) !important;
+  &:hover {
+    @media (hover: hover) {
+      fill: var(--color-brand-500) !important;
+    }
+  }
+  &:is(.dark *) {
+    fill: var(--color-gray-700) !important;
+  }
+  &:is(.dark *) {
+    &:hover {
+      @media (hover: hover) {
+        fill: var(--color-brand-500) !important;
+      }
+    }
+  }
+}
+.jvm-marker.jvm-element {
+  stroke: var(--color-gray-200) !important;
+  &:is(.dark *) {
+    stroke: var(--color-gray-800) !important;
+  }
+}
+.stocks-slider-outer .swiper-button-next:after,
+.stocks-slider-outer .swiper-button-prev:after {
+  display: none;
+}
+.stocks-slider-outer .swiper-button-next,
+.stocks-slider-outer .swiper-button-prev {
+  position: static !important;
+  margin-top: calc(var(--spacing) * 0);
+  height: calc(var(--spacing) * 8);
+  width: calc(var(--spacing) * 9);
+  border-radius: calc(infinity * 1px);
+  border-style: var(--tw-border-style);
+  border-width: 1px;
+  border-color: var(--color-gray-200);
+  color: var(--color-gray-700) !important;
+  transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, backdrop-filter;
+  -webkit-transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+          transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+  -webkit-transition-duration: var(--tw-duration, var(--default-transition-duration));
+          transition-duration: var(--tw-duration, var(--default-transition-duration));
+  &:hover {
+    @media (hover: hover) {
+      background-color: var(--color-gray-100);
+    }
+  }
+  &:is(.dark *) {
+    border-color: var(--color-gray-800);
+  }
+  &:is(.dark *) {
+    background-color: var(--color-gray-800);
+  }
+  &:is(.dark *) {
+    color: var(--color-gray-400) !important;
+  }
+}
+.stocks-slider-outer .swiper-button-next.swiper-button-disabled,
+.stocks-slider-outer .swiper-button-prev.swiper-button-disabled {
+  background-color: var(--color-white);
+  opacity: 100%;
+  &:is(.dark *) {
+    background-color: var(--color-gray-900);
+  }
+}
+.stocks-slider-outer .swiper-button-next svg,
+.stocks-slider-outer .swiper-button-prev svg {
+  height: auto !important;
+  width: auto !important;
+}
+.flatpickr-wrapper {
+  width: 100%;
+}
+.flatpickr-calendar {
+  margin-top: calc(var(--spacing) * 2);
+  border-radius: var(--radius-xl) !important;
+  padding: calc(var(--spacing) * 5) !important;
+  color: var(--color-gray-500) !important;
+  @media (width >= 375px) {
+    width: auto !important;
+  }
+  &:is(.dark *) {
+    background-color: var(--color-gray-dark) !important;
+  }
+  &:is(.dark *) {
+    color: var(--color-gray-400) !important;
+  }
+  &:is(.dark *) {
+    --tw-shadow: 0px 20px 24px -4px var(--tw-shadow-color, rgba(16, 24, 40, 0.08)), 0px 8px 8px -4px var(--tw-shadow-color, rgba(16, 24, 40, 0.03));
+    -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+            box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+  }
+}
+.flatpickr-months .flatpickr-prev-month:hover svg,
+.flatpickr-months .flatpickr-next-month:hover svg {
+  stroke: var(--color-brand-500);
+}
+.flatpickr-calendar.arrowTop:before,
+.flatpickr-calendar.arrowTop:after {
+  display: none;
+}
+.flatpickr-current-month .cur-month,
+.flatpickr-current-month input.cur-year {
+  height: auto !important;
+  padding-top: calc(var(--spacing) * 0) !important;
+  font-size: var(--text-lg) !important;
+  line-height: var(--tw-leading, var(--text-lg--line-height)) !important;
+  --tw-font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-medium) !important;
+  color: var(--color-gray-800) !important;
+  &:is(.dark *) {
+    color: color-mix(in oklab, var(--color-white) 90%, transparent) !important;
+  }
+}
+.flatpickr-prev-month,
+.flatpickr-next-month {
+  padding: calc(var(--spacing) * 0) !important;
+}
+.flatpickr-weekdays {
+  margin-top: calc(var(--spacing) * 6);
+  margin-bottom: calc(var(--spacing) * 4);
+  height: auto;
+}
+.flatpickr-weekday {
+  font-size: var(--text-theme-sm) !important;
+  line-height: var(--tw-leading, var(--text-theme-sm--line-height)) !important;
+  --tw-font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-medium) !important;
+  color: var(--color-gray-500) !important;
+  &:is(.dark *) {
+    color: var(--color-gray-400) !important;
+  }
+}
+.flatpickr-day {
+  display: -webkit-box !important;
+  display: -ms-flexbox !important;
+  display: flex !important;
+  -webkit-box-align: center !important;
+      -ms-flex-align: center !important;
+          align-items: center !important;
+  font-size: var(--text-theme-sm) !important;
+  line-height: var(--tw-leading, var(--text-theme-sm--line-height)) !important;
+  --tw-font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-medium) !important;
+  color: var(--color-gray-800) !important;
+  &:is(.dark *) {
+    color: color-mix(in oklab, var(--color-white) 90%, transparent) !important;
+  }
+  &:is(.dark *) {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-gray-300) !important;
+      }
+    }
+  }
+  &:is(.dark *) {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-900) !important;
+      }
+    }
+  }
+}
+.flatpickr-day.nextMonthDay,
+.flatpickr-day.prevMonthDay {
+  color: var(--color-gray-400) !important;
+}
+.flatpickr-months .flatpickr-prev-month,
+.flatpickr-months .flatpickr-next-month {
+  top: calc(var(--spacing) * 7) !important;
+  &:is(.dark *) {
+    fill: var(--color-white) !important;
+  }
+  &:is(.dark *) {
+    color: var(--color-white) !important;
+  }
+}
+.flatpickr-months .flatpickr-prev-month.flatpickr-prev-month,
+.flatpickr-months .flatpickr-next-month.flatpickr-prev-month {
+  left: calc(var(--spacing) * 7) !important;
+}
+.flatpickr-months .flatpickr-prev-month.flatpickr-next-month,
+.flatpickr-months .flatpickr-next-month.flatpickr-next-month {
+  right: calc(var(--spacing) * 7) !important;
+}
+span.flatpickr-weekday,
+.flatpickr-months .flatpickr-month {
+  &:is(.dark *) {
+    fill: var(--color-white) !important;
+  }
+  &:is(.dark *) {
+    color: var(--color-white) !important;
+  }
+}
+.flatpickr-day.inRange {
+  -webkit-box-shadow: -5px 0 0 #f9fafb,
+    5px 0 0 #f9fafb !important;
+          box-shadow: -5px 0 0 #f9fafb,
+    5px 0 0 #f9fafb !important;
+  &:is(.dark *) {
+    --tw-shadow: -5px 0 0 var(--tw-shadow-color, #262d3c), 5px 0 0 var(--tw-shadow-color, #262d3c);
+    -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+            box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+  }
+}
+.flatpickr-day.inRange,
+.flatpickr-day.prevMonthDay.inRange,
+.flatpickr-day.nextMonthDay.inRange,
+.flatpickr-day.today.inRange,
+.flatpickr-day.prevMonthDay.today.inRange,
+.flatpickr-day.nextMonthDay.today.inRange,
+.flatpickr-day:hover,
+.flatpickr-day.prevMonthDay:hover,
+.flatpickr-day.nextMonthDay:hover,
+.flatpickr-day:focus,
+.flatpickr-day.prevMonthDay:focus,
+.flatpickr-day.nextMonthDay:focus {
+  border-color: var(--color-gray-50) !important;
+  background-color: var(--color-gray-50) !important;
+  &:is(.dark *) {
+    border-style: var(--tw-border-style) !important;
+    border-width: 0px !important;
+  }
+  &:is(.dark *) {
+    border-color: color-mix(in oklab, var(--color-white) 5%, transparent) !important;
+  }
+  &:is(.dark *) {
+    background-color: color-mix(in oklab, var(--color-white) 5%, transparent) !important;
+  }
+}
+.flatpickr-day.selected,
+.flatpickr-day.startRange,
+.flatpickr-day.selected,
+.flatpickr-day.endRange {
+  color: var(--color-white) !important;
+  &:is(.dark *) {
+    color: var(--color-white) !important;
+  }
+}
+.flatpickr-day.selected,
+.flatpickr-day.startRange,
+.flatpickr-day.endRange,
+.flatpickr-day.selected.inRange,
+.flatpickr-day.startRange.inRange,
+.flatpickr-day.endRange.inRange,
+.flatpickr-day.selected:focus,
+.flatpickr-day.startRange:focus,
+.flatpickr-day.endRange:focus,
+.flatpickr-day.selected:hover,
+.flatpickr-day.startRange:hover,
+.flatpickr-day.endRange:hover,
+.flatpickr-day.selected.prevMonthDay,
+.flatpickr-day.startRange.prevMonthDay,
+.flatpickr-day.endRange.prevMonthDay,
+.flatpickr-day.selected.nextMonthDay,
+.flatpickr-day.startRange.nextMonthDay,
+.flatpickr-day.endRange.nextMonthDay {
+  background: #465fff;
+  border-color: var(--color-brand-500) !important;
+  background-color: var(--color-brand-500) !important;
+  &:hover {
+    @media (hover: hover) {
+      border-color: var(--color-brand-500) !important;
+    }
+  }
+  &:hover {
+    @media (hover: hover) {
+      background-color: var(--color-brand-500) !important;
+    }
+  }
+}
+.flatpickr-day.selected.startRange + .endRange:not(:nth-child(7n + 1)),
+.flatpickr-day.startRange.startRange + .endRange:not(:nth-child(7n + 1)),
+.flatpickr-day.endRange.startRange + .endRange:not(:nth-child(7n + 1)) {
+  -webkit-box-shadow: -10px 0 0 #465fff;
+          box-shadow: -10px 0 0 #465fff;
+}
+.flatpickr-months .flatpickr-prev-month svg,
+.flatpickr-months .flatpickr-next-month svg,
+.flatpickr-months .flatpickr-prev-month,
+.flatpickr-months .flatpickr-next-month {
+  &:hover {
+    @media (hover: hover) {
+      fill: none !important;
+    }
+  }
+}
+.flatpickr-months .flatpickr-prev-month:hover svg,
+.flatpickr-months .flatpickr-next-month:hover svg {
+  fill: none !important;
+}
+.flatpickr-calendar.static {
+  right: calc(var(--spacing) * 0);
+}
+.fc .fc-view-harness {
+  &::-webkit-scrollbar {
+    width: calc(var(--spacing) * 1.5);
+    height: calc(var(--spacing) * 1.5);
+  }
+  &::-webkit-scrollbar-track {
+    border-radius: calc(infinity * 1px);
+  }
+  &::-webkit-scrollbar-thumb {
+    border-radius: calc(infinity * 1px);
+    background-color: var(--color-gray-200);
+  }
+  max-width: 100%;
+  overflow-x: auto;
+}
+.fc-dayGridMonth-view.fc-view.fc-daygrid {
+  min-width: 718px;
+}
+.fc .fc-scrollgrid-section > * {
+  border-right-width: 0;
+  border-bottom-width: 0;
+}
+.fc .fc-scrollgrid {
+  border-left-width: 0;
+}
+.fc .fc-toolbar.fc-header-toolbar {
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  gap: calc(var(--spacing) * 4);
+  padding-inline: calc(var(--spacing) * 6);
+  padding-top: calc(var(--spacing) * 6);
+  @media (width >= 640px) {
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: row;
+            flex-direction: row;
+  }
+}
+.fc-button-group {
+  gap: calc(var(--spacing) * 2);
+}
+.fc-button-group .fc-button {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  height: calc(var(--spacing) * 10);
+  width: calc(var(--spacing) * 10);
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  border-radius: var(--radius-lg) !important;
+  border-style: var(--tw-border-style);
+  border-width: 1px;
+  border-color: var(--color-gray-200);
+  background-color: transparent;
+  &:hover {
+    @media (hover: hover) {
+      border-color: var(--color-gray-200);
+    }
+  }
+  &:hover {
+    @media (hover: hover) {
+      background-color: var(--color-gray-50);
+    }
+  }
+  &:focus {
+    --tw-shadow: 0 0 #0000;
+    -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+            box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  &:active {
+    border-color: var(--color-gray-200) !important;
+  }
+  &:active {
+    background-color: transparent !important;
+  }
+  &:active {
+    --tw-shadow: 0 0 #0000;
+    -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+            box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+  }
+  &:is(.dark *) {
+    border-color: var(--color-gray-800);
+  }
+  &:is(.dark *) {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-gray-800);
+      }
+    }
+  }
+  &:is(.dark *) {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-900);
+      }
+    }
+  }
+  &:is(.dark *) {
+    &:active {
+      border-color: var(--color-gray-800) !important;
+    }
+  }
+}
+.fc-button-group .fc-button.fc-prev-button:before {
+  margin-top: calc(var(--spacing) * 1);
+  display: inline-block;
+  content: url("data:image/svg+xml,%3Csvg width=%2725%27 height=%2724%27 viewBox=%270 0 25 24%27 fill=%27none%27 xmlns=%27http://www.w3.org/2000/svg%27%3E%3Cpath d=%27M16.0068 6L9.75684 12.25L16.0068 18.5%27 stroke=%27%23344054%27 stroke-width=%271.5%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27/%3E%3C/svg%3E%0A");
+}
+.fc-button-group .fc-button.fc-next-button:before {
+  margin-top: calc(var(--spacing) * 1);
+  display: inline-block;
+  content: url("data:image/svg+xml,%3Csvg width=%2725%27 height=%2724%27 viewBox=%270 0 25 24%27 fill=%27none%27 xmlns=%27http://www.w3.org/2000/svg%27%3E%3Cpath d=%27M9.50684 19L15.7568 12.75L9.50684 6.5%27 stroke=%27%23344054%27 stroke-width=%271.5%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27/%3E%3C/svg%3E%0A");
+}
+.dark .fc-button-group .fc-button.fc-prev-button:before {
+  content: url("data:image/svg+xml,%3Csvg width=%2725%27 height=%2724%27 viewBox=%270 0 25 24%27 fill=%27none%27 xmlns=%27http://www.w3.org/2000/svg%27%3E%3Cpath d=%27M16.0068 6L9.75684 12.25L16.0068 18.5%27 stroke=%27%2398A2B3%27 stroke-width=%271.5%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27/%3E%3C/svg%3E%0A");
+}
+.dark .fc-button-group .fc-button.fc-next-button:before {
+  content: url("data:image/svg+xml,%3Csvg width=%2725%27 height=%2724%27 viewBox=%270 0 25 24%27 fill=%27none%27 xmlns=%27http://www.w3.org/2000/svg%27%3E%3Cpath d=%27M9.50684 19L15.7568 12.75L9.50684 6.5%27 stroke=%27%2398A2B3%27 stroke-width=%271.5%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27/%3E%3C/svg%3E%0A");
+}
+.fc-button-group .fc-button .fc-icon {
+  display: none;
+}
+.fc-addEventButton-button {
+  border-radius: var(--radius-lg) !important;
+  border-style: var(--tw-border-style) !important;
+  border-width: 0px !important;
+  background-color: var(--color-brand-500) !important;
+  padding-inline: calc(var(--spacing) * 4) !important;
+  padding-block: calc(var(--spacing) * 2.5) !important;
+  font-size: var(--text-sm) !important;
+  line-height: var(--tw-leading, var(--text-sm--line-height)) !important;
+  --tw-font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-medium) !important;
+  &:hover {
+    @media (hover: hover) {
+      background-color: var(--color-brand-600) !important;
+    }
+  }
+  &:focus {
+    --tw-shadow: 0 0 #0000;
+    -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+            box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+  }
+}
+.fc-toolbar-title {
+  font-size: var(--text-lg) !important;
+  line-height: var(--tw-leading, var(--text-lg--line-height)) !important;
+  --tw-font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-medium) !important;
+  color: var(--color-gray-800);
+  &:is(.dark *) {
+    color: color-mix(in oklab, var(--color-white) 90%, transparent);
+  }
+}
+.fc-header-toolbar.fc-toolbar .fc-toolbar-chunk:last-child {
+  border-radius: var(--radius-lg);
+  background-color: var(--color-gray-100);
+  padding: calc(var(--spacing) * 0.5);
+  &:is(.dark *) {
+    background-color: var(--color-gray-900);
+  }
+}
+.fc-header-toolbar.fc-toolbar .fc-toolbar-chunk:last-child .fc-button {
+  height: auto !important;
+  width: auto !important;
+  border-radius: var(--radius-md);
+  border-style: var(--tw-border-style) !important;
+  border-width: 0px !important;
+  background-color: transparent;
+  padding-inline: calc(var(--spacing) * 5) !important;
+  padding-block: calc(var(--spacing) * 2) !important;
+  font-size: var(--text-sm);
+  line-height: var(--tw-leading, var(--text-sm--line-height));
+  --tw-font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-500);
+  &:hover {
+    @media (hover: hover) {
+      color: var(--color-gray-700);
+    }
+  }
+  &:focus {
+    --tw-shadow: 0 0 #0000;
+    -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+            box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+  }
+  &:is(.dark *) {
+    color: var(--color-gray-400);
+  }
+}
+.fc-header-toolbar.fc-toolbar
+  .fc-toolbar-chunk:last-child
+  .fc-button.fc-button-active {
+  background-color: var(--color-white);
+  color: var(--color-gray-900);
+  &:is(.dark *) {
+    background-color: var(--color-gray-800);
+  }
+  &:is(.dark *) {
+    color: var(--color-white);
+  }
+}
+.fc-theme-standard th {
+  border-inline-style: var(--tw-border-style) !important;
+  border-inline-width: 0px !important;
+  border-top-style: var(--tw-border-style);
+  border-top-width: 1px;
+  border-color: var(--color-gray-200) !important;
+  background-color: var(--color-gray-50);
+  text-align: left !important;
+  &:is(.dark *) {
+    border-color: var(--color-gray-800) !important;
+  }
+  &:is(.dark *) {
+    background-color: var(--color-gray-900);
+  }
+}
+.fc-theme-standard td,
+.fc-theme-standard .fc-scrollgrid {
+  border-color: var(--color-gray-200) !important;
+  &:is(.dark *) {
+    border-color: var(--color-gray-800) !important;
+  }
+}
+.fc .fc-col-header-cell-cushion {
+  padding-inline: calc(var(--spacing) * 5) !important;
+  padding-block: calc(var(--spacing) * 4) !important;
+  font-size: var(--text-sm);
+  line-height: var(--tw-leading, var(--text-sm--line-height));
+  --tw-font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-400);
+  text-transform: uppercase;
+}
+.fc .fc-daygrid-day.fc-day-today {
+  background-color: transparent;
+}
+.fc .fc-daygrid-day {
+  padding: calc(var(--spacing) * 2);
+}
+.fc .fc-daygrid-day.fc-day-today .fc-scrollgrid-sync-inner {
+  border-radius: var(--radius-sm);
+  background-color: var(--color-gray-100);
+  &:is(.dark *) {
+    background-color: color-mix(in oklab, var(--color-white) 3%, transparent);
+  }
+}
+.fc .fc-daygrid-day-number {
+  padding: calc(var(--spacing) * 3) !important;
+  font-size: var(--text-sm);
+  line-height: var(--tw-leading, var(--text-sm--line-height));
+  --tw-font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-700);
+  &:is(.dark *) {
+    color: var(--color-gray-400);
+  }
+}
+.fc .fc-daygrid-day-top {
+  -webkit-box-orient: horizontal !important;
+  -webkit-box-direction: normal !important;
+      -ms-flex-direction: row !important;
+          flex-direction: row !important;
+}
+.fc .fc-day-other .fc-daygrid-day-top {
+  opacity: 1;
+}
+.fc .fc-day-other .fc-daygrid-day-top .fc-daygrid-day-number {
+  color: var(--color-gray-400);
+  &:is(.dark *) {
+    color: color-mix(in oklab, var(--color-white) 30%, transparent);
+  }
+}
+.event-fc-color {
+  border-radius: var(--radius-lg);
+  padding-block: calc(var(--spacing) * 2.5);
+  padding-right: calc(var(--spacing) * 3);
+  padding-left: calc(var(--spacing) * 4);
+}
+.event-fc-color .fc-event-title {
+  padding: calc(var(--spacing) * 0);
+  font-size: var(--text-sm);
+  line-height: var(--tw-leading, var(--text-sm--line-height));
+  --tw-font-weight: var(--font-weight-normal);
+  font-weight: var(--font-weight-normal);
+  color: var(--color-gray-700);
+}
+.fc-daygrid-event-dot {
+  margin-right: calc(var(--spacing) * 3);
+  margin-left: calc(var(--spacing) * 0);
+  height: calc(var(--spacing) * 5);
+  width: calc(var(--spacing) * 1);
+  border-radius: var(--radius-sm);
+  --tw-border-style: none;
+  border-style: none;
+}
+.fc-event {
+  &:focus {
+    --tw-shadow: 0 0 #0000;
+    -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+            box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+}
+.fc-daygrid-event.fc-event-start {
+  margin-left: calc(var(--spacing) * 3) !important;
+}
+.event-fc-color.fc-bg-success {
+  border-color: var(--color-success-50);
+  background-color: var(--color-success-50);
+}
+.event-fc-color.fc-bg-danger {
+  border-color: var(--color-error-50);
+  background-color: var(--color-error-50);
+}
+.event-fc-color.fc-bg-primary {
+  border-color: var(--color-brand-50);
+  background-color: var(--color-brand-50);
+}
+.event-fc-color.fc-bg-warning {
+  border-color: var(--color-orange-50);
+  background-color: var(--color-orange-50);
+}
+.event-fc-color.fc-bg-success .fc-daygrid-event-dot {
+  background-color: var(--color-success-500);
+}
+.event-fc-color.fc-bg-danger .fc-daygrid-event-dot {
+  background-color: var(--color-error-500);
+}
+.event-fc-color.fc-bg-primary .fc-daygrid-event-dot {
+  background-color: var(--color-brand-500);
+}
+.event-fc-color.fc-bg-warning .fc-daygrid-event-dot {
+  background-color: var(--color-orange-500);
+}
+.fc-direction-ltr .fc-timegrid-slot-label-frame {
+  padding-inline: calc(var(--spacing) * 3);
+  padding-block: calc(var(--spacing) * 1.5);
+  text-align: left;
+  font-size: var(--text-sm);
+  line-height: var(--tw-leading, var(--text-sm--line-height));
+  --tw-font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-500);
+  &:is(.dark *) {
+    color: var(--color-gray-400);
+  }
+}
+.fc .fc-timegrid-axis-cushion {
+  font-size: var(--text-sm);
+  line-height: var(--tw-leading, var(--text-sm--line-height));
+  --tw-font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-gray-500);
+  &:is(.dark *) {
+    color: var(--color-gray-400);
+  }
+}
+.input-date-icon::-webkit-inner-spin-button,
+.input-date-icon::-webkit-calendar-picker-indicator {
+  opacity: 0;
+  -webkit-appearance: none;
+}
+.swiper-button-prev svg,
+.swiper-button-next svg {
+  height: auto !important;
+  width: auto !important;
+}
+.carouselTwo .swiper-button-next:after,
+.carouselTwo .swiper-button-prev:after,
+.carouselFour .swiper-button-next:after,
+.carouselFour .swiper-button-prev:after {
+  display: none;
+}
+.carouselTwo .swiper-button-next.swiper-button-disabled,
+.carouselTwo .swiper-button-prev.swiper-button-disabled,
+.carouselFour .swiper-button-next.swiper-button-disabled,
+.carouselFour .swiper-button-prev.swiper-button-disabled {
+  background-color: color-mix(in oklab, var(--color-white) 60%, transparent);
+  opacity: 100% !important;
+}
+.carouselTwo .swiper-button-next,
+.carouselTwo .swiper-button-prev,
+.carouselFour .swiper-button-next,
+.carouselFour .swiper-button-prev {
+  height: calc(var(--spacing) * 10);
+  width: calc(var(--spacing) * 10);
+  border-radius: calc(infinity * 1px);
+  border-style: var(--tw-border-style);
+  border-width: 0.5px;
+  border-color: color-mix(in oklab, var(--color-white) 10%, transparent);
+  background-color: color-mix(in oklab, var(--color-white) 90%, transparent);
+  color: var(--color-gray-700) !important;
+  --tw-shadow: 0px 1px 2px 0px var(--tw-shadow-color, rgba(16, 24, 40, 0.1)), 0px 1px 3px 0px var(--tw-shadow-color, rgba(16, 24, 40, 0.1));
+  -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+          box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  --tw-backdrop-blur: blur(10px);
+  backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+}
+.carouselTwo .swiper-button-prev,
+.carouselFour .swiper-button-prev {
+  left: calc(var(--spacing) * 3) !important;
+  @media (width >= 640px) {
+    left: calc(var(--spacing) * 4) !important;
+  }
+}
+.carouselTwo .swiper-button-next,
+.carouselFour .swiper-button-next {
+  right: calc(var(--spacing) * 3) !important;
+  @media (width >= 640px) {
+    right: calc(var(--spacing) * 4) !important;
+  }
+}
+.carouselThree .swiper-pagination,
+.carouselFour .swiper-pagination {
+  bottom: calc(var(--spacing) * 3) !important;
+  left: calc(1/2 * 100%) !important;
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto !important;
+  --tw-translate-x: calc(calc(1/2 * 100%) * -1);
+  translate: var(--tw-translate-x) var(--tw-translate-y);
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  gap: calc(var(--spacing) * 1.5);
+  border-radius: 40px;
+  border-style: var(--tw-border-style);
+  border-width: 0.5px;
+  border-color: color-mix(in oklab, var(--color-white) 10%, transparent);
+  background-color: color-mix(in oklab, var(--color-white) 60%, transparent);
+  padding-inline: calc(var(--spacing) * 2);
+  padding-block: calc(var(--spacing) * 1.5);
+  --tw-shadow: 0px 1px 2px 0px var(--tw-shadow-color, rgba(16, 24, 40, 0.1)), 0px 1px 3px 0px var(--tw-shadow-color, rgba(16, 24, 40, 0.1));
+  -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+          box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  --tw-backdrop-blur: blur(10px);
+  backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  @media (width >= 640px) {
+    bottom: calc(var(--spacing) * 5) !important;
+  }
+}
+.carouselThree .swiper-pagination-bullet,
+.carouselFour .swiper-pagination-bullet {
+  margin: calc(var(--spacing) * 0) !important;
+  height: calc(var(--spacing) * 2.5);
+  width: calc(var(--spacing) * 2.5);
+  background-color: var(--color-white);
+  opacity: 100%;
+  --tw-shadow: 0px 1px 2px 0px var(--tw-shadow-color, rgba(16, 24, 40, 0.05));
+  -webkit-box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+          box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  --tw-duration: 200ms;
+  -webkit-transition-duration: 200ms;
+          transition-duration: 200ms;
+  --tw-ease: var(--ease-in-out);
+  -webkit-transition-timing-function: var(--ease-in-out);
+          transition-timing-function: var(--ease-in-out);
+}
+.carouselThree .swiper-pagination-bullet-active,
+.carouselFour .swiper-pagination-bullet-active {
+  width: calc(var(--spacing) * 6.5);
+  border-radius: var(--radius-xl);
+}
+.form-check-input:checked ~ span {
+  border-style: var(--tw-border-style);
+  border-width: 6px;
+  border-color: var(--color-brand-500);
+  &:is(.dark *) {
+    border-color: var(--color-brand-500);
+  }
+}
+.taskCheckbox:checked ~ .box span {
+  opacity: 100%;
+}
+.taskCheckbox:checked ~ p {
+  color: var(--color-gray-400);
+  text-decoration-line: line-through;
+}
+.taskCheckbox:checked ~ .box {
+  border-color: var(--color-brand-500);
+  background-color: var(--color-brand-500);
+  &:is(.dark *) {
+    border-color: var(--color-brand-500);
+  }
+}
+.task {
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
+}
+.task.is-dragging {
+  border-radius: 0.75rem;
+  -webkit-box-shadow: 0px 1px 3px 0px rgba(16, 24, 40, 0.1),
+    0px 1px 2px 0px rgba(16, 24, 40, 0.06);
+          box-shadow: 0px 1px 3px 0px rgba(16, 24, 40, 0.1),
+    0px 1px 2px 0px rgba(16, 24, 40, 0.06);
+  opacity: 0.8;
+  cursor: -webkit-grabbing;
+  cursor: grabbing;
+}
+@-webkit-keyframes spin {
+  to {
+    -webkit-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+@keyframes spin {
+  to {
+    -webkit-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+@-webkit-keyframes ping {
+  75%, 100% {
+    -webkit-transform: scale(2);
+            transform: scale(2);
+    opacity: 0;
+  }
+}
+@keyframes ping {
+  75%, 100% {
+    -webkit-transform: scale(2);
+            transform: scale(2);
+    opacity: 0;
+  }
+}
+@property --tw-translate-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-translate-y {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-translate-z {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-font-weight {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: rotateX(0);
+}
+@property --tw-rotate-y {
+  syntax: "*";
+  inherits: false;
+  initial-value: rotateY(0);
+}
+@property --tw-rotate-z {
+  syntax: "*";
+  inherits: false;
+  initial-value: rotateZ(0);
+}
+@property --tw-skew-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: skewX(0);
+}
+@property --tw-skew-y {
+  syntax: "*";
+  inherits: false;
+  initial-value: skewY(0);
+}
+@property --tw-space-y-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-space-x-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-divide-y-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-border-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
+@property --tw-leading {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-tracking {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-inset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-inset-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ring-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-inset-ring-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-inset-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-ring-inset {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ring-offset-width {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+@property --tw-ring-offset-color {
+  syntax: "*";
+  inherits: false;
+  initial-value: #fff;
+}
+@property --tw-ring-offset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-blur {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-brightness {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-contrast {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-grayscale {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-hue-rotate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-invert {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-opacity {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-saturate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-sepia {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-drop-shadow {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-blur {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-brightness {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-contrast {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-grayscale {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-hue-rotate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-invert {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-opacity {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-saturate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-sepia {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-duration {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ease {
+  syntax: "*";
+  inherits: false;
+}
+

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,7 +1,2 @@
 import './bootstrap';
-
-import Alpine from 'alpinejs';
-
-window.Alpine = Alpine;
-
-Alpine.start();
+import './tailadmin';

--- a/resources/js/components/calendar-init.js
+++ b/resources/js/components/calendar-init.js
@@ -1,0 +1,315 @@
+import { Calendar } from "@fullcalendar/core";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import listPlugin from "@fullcalendar/list";
+import timeGridPlugin from "@fullcalendar/timegrid";
+import interactionPlugin from "@fullcalendar/interaction";
+
+/*========Calender Js=========*/
+/*==========================*/
+
+document.addEventListener("DOMContentLoaded", function () {
+  const calendarWrapper = document.querySelector("#calendar");
+
+  if (calendarWrapper) {
+    /*=================*/
+    //  Calender Date variable
+    /*=================*/
+    const newDate = new Date();
+    const getDynamicMonth = () => {
+      const month = newDate.getMonth() + 1;
+      return month < 10 ? `0${month}` : `${month}`;
+    };
+
+    /*=================*/
+    // Calender Modal Elements
+    /*=================*/
+    const getModalTitleEl = document.querySelector("#event-title");
+    const getModalStartDateEl = document.querySelector("#event-start-date");
+    const getModalEndDateEl = document.querySelector("#event-end-date");
+    const getModalAddBtnEl = document.querySelector(".btn-add-event");
+    const getModalUpdateBtnEl = document.querySelector(".btn-update-event");
+    const calendarsEvents = {
+      Danger: "danger",
+      Success: "success",
+      Primary: "primary",
+      Warning: "warning",
+    };
+
+    /*=====================*/
+    // Calendar Elements and options
+    /*=====================*/
+    const calendarEl = document.querySelector("#calendar");
+
+    const calendarHeaderToolbar = {
+      left: "prev,next addEventButton",
+      center: "title",
+      right: "dayGridMonth,timeGridWeek,timeGridDay",
+    };
+
+    const calendarEventsList = [
+      {
+        id: 1,
+        title: "Event Conf.",
+        start: `${newDate.getFullYear()}-${getDynamicMonth()}-01`,
+        extendedProps: { calendar: "Danger" },
+      },
+      {
+        id: 2,
+        title: "Seminar #4",
+        start: `${newDate.getFullYear()}-${getDynamicMonth()}-07`,
+        end: `${newDate.getFullYear()}-${getDynamicMonth()}-10`,
+        extendedProps: { calendar: "Success" },
+      },
+      {
+        groupId: "999",
+        id: 3,
+        title: "Meeting #5",
+        start: `${newDate.getFullYear()}-${getDynamicMonth()}-09T16:00:00`,
+        extendedProps: { calendar: "Primary" },
+      },
+      {
+        groupId: "999",
+        id: 4,
+        title: "Submission #1",
+        start: `${newDate.getFullYear()}-${getDynamicMonth()}-16T16:00:00`,
+        extendedProps: { calendar: "Warning" },
+      },
+      {
+        id: 5,
+        title: "Seminar #6",
+        start: `${newDate.getFullYear()}-${getDynamicMonth()}-11`,
+        end: `${newDate.getFullYear()}-${getDynamicMonth()}-13`,
+        extendedProps: { calendar: "Danger" },
+      },
+      {
+        id: 6,
+        title: "Meeting 3",
+        start: `${newDate.getFullYear()}-${getDynamicMonth()}-12T10:30:00`,
+        end: `${newDate.getFullYear()}-${getDynamicMonth()}-12T12:30:00`,
+        extendedProps: { calendar: "Success" },
+      },
+      {
+        id: 7,
+        title: "Meetup #",
+        start: `${newDate.getFullYear()}-${getDynamicMonth()}-12T12:00:00`,
+        extendedProps: { calendar: "Primary" },
+      },
+      {
+        id: 8,
+        title: "Submission",
+        start: `${newDate.getFullYear()}-${getDynamicMonth()}-12T14:30:00`,
+        extendedProps: { calendar: "Warning" },
+      },
+      {
+        id: 9,
+        title: "Attend event",
+        start: `${newDate.getFullYear()}-${getDynamicMonth()}-13T07:00:00`,
+        extendedProps: { calendar: "Success" },
+      },
+      {
+        id: 10,
+        title: "Project submission #2",
+        start: `${newDate.getFullYear()}-${getDynamicMonth()}-28`,
+        extendedProps: { calendar: "Primary" },
+      },
+    ];
+
+    /*=====================*/
+    // Modal Functions
+    /*=====================*/
+    const openModal = () => {
+      document.getElementById("eventModal").style.display = "flex";
+    };
+
+    const closeModal = () => {
+      document.getElementById("eventModal").style.display = "none";
+      resetModalFields();
+    };
+
+    // Close modal when clicking outside of it
+    window.onclick = function (event) {
+      const modal = document.getElementById("eventModal");
+      if (event.target === modal) {
+        closeModal();
+      }
+    };
+
+    /*=====================*/
+    // Calendar Select fn.
+    /*=====================*/
+    const calendarSelect = (info) => {
+      resetModalFields();
+
+      getModalAddBtnEl.style.display = "flex";
+      getModalUpdateBtnEl.style.display = "none";
+      openModal();
+      getModalStartDateEl.value = info.startStr;
+      getModalEndDateEl.value = info.endStr || info.startStr;
+      getModalTitleEl.value = "";
+    };
+
+    /*=====================*/
+    // Calendar AddEvent fn.
+    /*=====================*/
+    const calendarAddEvent = () => {
+      const currentDate = new Date();
+      const dd = String(currentDate.getDate()).padStart(2, "0");
+      const mm = String(currentDate.getMonth() + 1).padStart(2, "0");
+      const yyyy = currentDate.getFullYear();
+      const combineDate = `${yyyy}-${mm}-${dd}T00:00:00`;
+
+      getModalAddBtnEl.style.display = "flex";
+      getModalUpdateBtnEl.style.display = "none";
+      openModal();
+      getModalStartDateEl.value = combineDate;
+    };
+
+    /*=====================*/
+    // Calender Event Function
+    /*=====================*/
+    const calendarEventClick = (info) => {
+      const eventObj = info.event;
+
+      if (eventObj.url) {
+        window.open(eventObj.url);
+        info.jsEvent.preventDefault();
+      } else {
+        const getModalEventId = eventObj._def.publicId;
+        const getModalEventLevel = eventObj._def.extendedProps.calendar;
+        const getModalCheckedRadioBtnEl = document.querySelector(
+          `input[value="${getModalEventLevel}"]`,
+        );
+
+        getModalTitleEl.value = eventObj.title;
+        getModalStartDateEl.value = eventObj.startStr.slice(0, 10);
+        getModalEndDateEl.value = eventObj.endStr
+          ? eventObj.endStr.slice(0, 10)
+          : "";
+        if (getModalCheckedRadioBtnEl) {
+          getModalCheckedRadioBtnEl.checked = true;
+        }
+        getModalUpdateBtnEl.dataset.fcEventPublicId = getModalEventId;
+        getModalAddBtnEl.style.display = "none";
+        getModalUpdateBtnEl.style.display = "block";
+        openModal();
+      }
+    };
+
+    /*=====================*/
+    // Active Calender
+    /*=====================*/
+    const calendar = new Calendar(calendarEl, {
+      plugins: [dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin],
+      selectable: true,
+      initialView: "dayGridMonth",
+      initialDate: `${newDate.getFullYear()}-${getDynamicMonth()}-07`,
+      headerToolbar: calendarHeaderToolbar,
+      events: calendarEventsList,
+      select: calendarSelect,
+      eventClick: calendarEventClick,
+      dateClick: calendarAddEvent,
+      customButtons: {
+        addEventButton: {
+          text: "Add Event +",
+          click: calendarAddEvent,
+        },
+      },
+      eventClassNames({ event: calendarEvent }) {
+        const getColorValue =
+          calendarsEvents[calendarEvent._def.extendedProps.calendar];
+        return [`event-fc-color`, `fc-bg-${getColorValue}`];
+      },
+    });
+
+    /*=====================*/
+    // Update Calender Event
+    /*=====================*/
+    getModalUpdateBtnEl.addEventListener("click", () => {
+      const getPublicID = getModalUpdateBtnEl.dataset.fcEventPublicId;
+      const getTitleUpdatedValue = getModalTitleEl.value;
+      const setModalStartDateValue = getModalStartDateEl.value;
+      const setModalEndDateValue = getModalEndDateEl.value;
+      const getEvent = calendar.getEventById(getPublicID);
+      const getModalUpdatedCheckedRadioBtnEl = document.querySelector(
+        'input[name="event-level"]:checked',
+      );
+
+      const getModalUpdatedCheckedRadioBtnValue =
+        getModalUpdatedCheckedRadioBtnEl
+          ? getModalUpdatedCheckedRadioBtnEl.value
+          : "";
+
+      getEvent.setProp("title", getTitleUpdatedValue);
+      getEvent.setDates(setModalStartDateValue, setModalEndDateValue);
+      getEvent.setExtendedProp("calendar", getModalUpdatedCheckedRadioBtnValue);
+      closeModal();
+    });
+
+    /*=====================*/
+    // Add Calender Event
+    /*=====================*/
+    getModalAddBtnEl.addEventListener("click", () => {
+      const getModalCheckedRadioBtnEl = document.querySelector(
+        'input[name="event-level"]:checked',
+      );
+
+      const getTitleValue = getModalTitleEl.value;
+      const setModalStartDateValue = getModalStartDateEl.value;
+      const setModalEndDateValue = getModalEndDateEl.value;
+      const getModalCheckedRadioBtnValue = getModalCheckedRadioBtnEl
+        ? getModalCheckedRadioBtnEl.value
+        : "";
+
+      calendar.addEvent({
+        id: Date.now(), // Use unique ID based on timestamp
+        title: getTitleValue,
+        start: setModalStartDateValue,
+        end: setModalEndDateValue,
+        allDay: true,
+        extendedProps: { calendar: getModalCheckedRadioBtnValue },
+      });
+      closeModal();
+    });
+
+    /*=====================*/
+    // Calendar Init
+    /*=====================*/
+    calendar.render();
+
+    // Reset modal fields when hidden
+    document.getElementById("eventModal").addEventListener("click", (event) => {
+      if (event.target.classList.contains("modal-close-btn")) {
+        closeModal();
+      }
+    });
+
+    function resetModalFields() {
+      getModalTitleEl.value = "";
+      getModalStartDateEl.value = "";
+      getModalEndDateEl.value = "";
+      const getModalIfCheckedRadioBtnEl = document.querySelector(
+        'input[name="event-level"]:checked',
+      );
+      if (getModalIfCheckedRadioBtnEl) {
+        getModalIfCheckedRadioBtnEl.checked = false;
+      }
+    }
+
+    document
+      .getElementById("eventModal")
+      .addEventListener("hidden.bs.modal", () => {
+        resetModalFields();
+      });
+
+    // Close modal when clicking on close button or outside modal
+    document.querySelectorAll(".modal-close-btn").forEach((btn) => {
+      btn.addEventListener("click", closeModal);
+    });
+
+    window.addEventListener("click", (event) => {
+      if (event.target === document.getElementById("eventModal")) {
+        closeModal();
+      }
+    });
+  }
+});

--- a/resources/js/components/charts/chart-01.js
+++ b/resources/js/components/charts/chart-01.js
@@ -1,0 +1,106 @@
+import ApexCharts from "apexcharts";
+
+// ===== chartOne
+const chart01 = () => {
+  const chartOneOptions = {
+    series: [
+      {
+        name: "Sales",
+        data: [168, 385, 201, 298, 187, 195, 291, 110, 215, 390, 280, 112],
+      },
+    ],
+    colors: ["#465fff"],
+    chart: {
+      fontFamily: "Outfit, sans-serif",
+      type: "bar",
+      height: 180,
+      toolbar: {
+        show: false,
+      },
+    },
+    plotOptions: {
+      bar: {
+        horizontal: false,
+        columnWidth: "39%",
+        borderRadius: 5,
+        borderRadiusApplication: "end",
+      },
+    },
+    dataLabels: {
+      enabled: false,
+    },
+    stroke: {
+      show: true,
+      width: 4,
+      colors: ["transparent"],
+    },
+    xaxis: {
+      categories: [
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr",
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Oct",
+        "Nov",
+        "Dec",
+      ],
+      axisBorder: {
+        show: false,
+      },
+      axisTicks: {
+        show: false,
+      },
+    },
+    legend: {
+      show: true,
+      position: "top",
+      horizontalAlign: "left",
+      fontFamily: "Outfit",
+
+      markers: {
+        radius: 99,
+      },
+    },
+    yaxis: {
+      title: false,
+    },
+    grid: {
+      yaxis: {
+        lines: {
+          show: true,
+        },
+      },
+    },
+    fill: {
+      opacity: 1,
+    },
+
+    tooltip: {
+      x: {
+        show: false,
+      },
+      y: {
+        formatter: function (val) {
+          return val;
+        },
+      },
+    },
+  };
+
+  const chartSelector = document.querySelectorAll("#chartOne");
+
+  if (chartSelector.length) {
+    const chartFour = new ApexCharts(
+      document.querySelector("#chartOne"),
+      chartOneOptions,
+    );
+    chartFour.render();
+  }
+};
+
+export default chart01;

--- a/resources/js/components/charts/chart-02.js
+++ b/resources/js/components/charts/chart-02.js
@@ -1,0 +1,65 @@
+import ApexCharts from "apexcharts";
+
+// ===== chartTwo
+const chart02 = () => {
+  const chartTwoOptions = {
+    series: [75.55],
+    colors: ["#465FFF"],
+    chart: {
+      fontFamily: "Outfit, sans-serif",
+      type: "radialBar",
+      height: 330,
+      sparkline: {
+        enabled: true,
+      },
+    },
+    plotOptions: {
+      radialBar: {
+        startAngle: -90,
+        endAngle: 90,
+        hollow: {
+          size: "80%",
+        },
+        track: {
+          background: "#E4E7EC",
+          strokeWidth: "100%",
+          margin: 5, // margin is in pixels
+        },
+        dataLabels: {
+          name: {
+            show: false,
+          },
+          value: {
+            fontSize: "36px",
+            fontWeight: "600",
+            offsetY: 60,
+            color: "#1D2939",
+            formatter: function (val) {
+              return val + "%";
+            },
+          },
+        },
+      },
+    },
+    fill: {
+      type: "solid",
+      colors: ["#465FFF"],
+    },
+    stroke: {
+      lineCap: "round",
+    },
+    labels: ["Progress"],
+  };
+
+  const chartSelector = document.querySelectorAll("#chartTwo");
+
+  if (chartSelector.length) {
+    const chartFour = new ApexCharts(
+      document.querySelector("#chartTwo"),
+      chartTwoOptions,
+    );
+    chartFour.render();
+  }
+};
+
+export default chart02;

--- a/resources/js/components/charts/chart-03.js
+++ b/resources/js/components/charts/chart-03.js
@@ -1,0 +1,113 @@
+import ApexCharts from "apexcharts";
+
+// ===== chartThree
+const chart03 = () => {
+  const chartThreeOptions = {
+    series: [
+      {
+        name: "Sales",
+        data: [180, 190, 170, 160, 175, 165, 170, 205, 230, 210, 240, 235],
+      },
+      {
+        name: "Revenue",
+        data: [40, 30, 50, 40, 55, 40, 70, 100, 110, 120, 150, 140],
+      },
+    ],
+    legend: {
+      show: false,
+      position: "top",
+      horizontalAlign: "left",
+    },
+    colors: ["#465FFF", "#9CB9FF"],
+    chart: {
+      fontFamily: "Outfit, sans-serif",
+      height: 310,
+      type: "area",
+      toolbar: {
+        show: false,
+      },
+    },
+    fill: {
+      gradient: {
+        enabled: true,
+        opacityFrom: 0.55,
+        opacityTo: 0,
+      },
+    },
+    stroke: {
+      curve: "straight",
+      width: ["2", "2"],
+    },
+
+    markers: {
+      size: 0,
+    },
+    labels: {
+      show: false,
+      position: "top",
+    },
+    grid: {
+      xaxis: {
+        lines: {
+          show: false,
+        },
+      },
+      yaxis: {
+        lines: {
+          show: true,
+        },
+      },
+    },
+    dataLabels: {
+      enabled: false,
+    },
+    tooltip: {
+      x: {
+        format: "dd MMM yyyy",
+      },
+    },
+    xaxis: {
+      type: "category",
+      categories: [
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr",
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Oct",
+        "Nov",
+        "Dec",
+      ],
+      axisBorder: {
+        show: false,
+      },
+      axisTicks: {
+        show: false,
+      },
+      tooltip: false,
+    },
+    yaxis: {
+      title: {
+        style: {
+          fontSize: "0px",
+        },
+      },
+    },
+  };
+
+  const chartSelector = document.querySelectorAll("#chartThree");
+
+  if (chartSelector.length) {
+    const chartThree = new ApexCharts(
+      document.querySelector("#chartThree"),
+      chartThreeOptions,
+    );
+    chartThree.render();
+  }
+};
+
+export default chart03;

--- a/resources/js/components/image-resize.js
+++ b/resources/js/components/image-resize.js
@@ -1,0 +1,302 @@
+/*
+ * @author https://twitter.com/blurspline / https://github.com/zz85
+ * See post @ http://www.lab4games.net/zz85/blog/2014/11/15/resizing-moving-snapping-windows-with-js-css/
+ */
+
+if (document.querySelectorAll("#pane").length) {
+  ("use strict");
+
+  // Minimum resizable area
+  var minWidth = 60;
+  var minHeight = 40;
+
+  // Thresholds
+  var FULLSCREEN_MARGINS = -10;
+  var MARGINS = 4;
+
+  // End of what's configurable.
+  var clicked = null;
+  var onRightEdge, onBottomEdge, onLeftEdge, onTopEdge;
+
+  var rightScreenEdge, bottomScreenEdge;
+
+  var preSnapped;
+
+  var b, x, y;
+
+  var redraw = false;
+
+  var pane = document.getElementById("pane");
+  var ghostpane = document.getElementById("ghostpane");
+
+  function setBounds(element, x, y, w, h) {
+    element.style.left = x + "px";
+    element.style.top = y + "px";
+    element.style.width = w + "px";
+    element.style.height = h + "px";
+  }
+
+  function hintHide() {
+    setBounds(ghostpane, b.left, b.top, b.width, b.height);
+    ghostpane.style.opacity = 0;
+
+    // var b = ghostpane.getBoundingClientRect();
+    // ghostpane.style.top = b.top + b.height / 2;
+    // ghostpane.style.left = b.left + b.width / 2;
+    // ghostpane.style.width = 0;
+    // ghostpane.style.height = 0;
+  }
+
+  // Mouse events
+  pane.addEventListener("mousedown", onMouseDown);
+  document.addEventListener("mousemove", onMove);
+  document.addEventListener("mouseup", onUp);
+
+  // Touch events
+  pane.addEventListener("touchstart", onTouchDown);
+  document.addEventListener("touchmove", onTouchMove);
+  document.addEventListener("touchend", onTouchEnd);
+
+  function onTouchDown(e) {
+    onDown(e.touches[0]);
+    e.preventDefault();
+  }
+
+  function onTouchMove(e) {
+    onMove(e.touches[0]);
+  }
+
+  function onTouchEnd(e) {
+    if (e.touches.length == 0) onUp(e.changedTouches[0]);
+  }
+
+  function onMouseDown(e) {
+    onDown(e);
+    e.preventDefault();
+  }
+
+  function onDown(e) {
+    calc(e);
+
+    var isResizing = onRightEdge || onBottomEdge || onTopEdge || onLeftEdge;
+
+    clicked = {
+      x: x,
+      y: y,
+      cx: e.clientX,
+      cy: e.clientY,
+      w: b.width,
+      h: b.height,
+      isResizing: isResizing,
+      isMoving: !isResizing && canMove(),
+      onTopEdge: onTopEdge,
+      onLeftEdge: onLeftEdge,
+      onRightEdge: onRightEdge,
+      onBottomEdge: onBottomEdge,
+    };
+  }
+
+  function canMove() {
+    return x > 0 && x < b.width && y > 0 && y < b.height && y < 30;
+  }
+
+  function calc(e) {
+    b = pane.getBoundingClientRect();
+    x = e.clientX - b.left;
+    y = e.clientY - b.top;
+
+    onTopEdge = y < MARGINS;
+    onLeftEdge = x < MARGINS;
+    onRightEdge = x >= b.width - MARGINS;
+    onBottomEdge = y >= b.height - MARGINS;
+
+    rightScreenEdge = window.innerWidth - MARGINS;
+    bottomScreenEdge = window.innerHeight - MARGINS;
+  }
+
+  var e;
+
+  function onMove(ee) {
+    calc(ee);
+
+    e = ee;
+
+    redraw = true;
+  }
+
+  function animate() {
+    requestAnimationFrame(animate);
+
+    if (!redraw) return;
+
+    redraw = false;
+
+    if (clicked && clicked.isResizing) {
+      if (clicked.onRightEdge) pane.style.width = Math.max(x, minWidth) + "px";
+      if (clicked.onBottomEdge)
+        pane.style.height = Math.max(y, minHeight) + "px";
+
+      if (clicked.onLeftEdge) {
+        var currentWidth = Math.max(
+          clicked.cx - e.clientX + clicked.w,
+          minWidth,
+        );
+        if (currentWidth > minWidth) {
+          pane.style.width = currentWidth + "px";
+          pane.style.left = e.clientX + "px";
+        }
+      }
+
+      if (clicked.onTopEdge) {
+        var currentHeight = Math.max(
+          clicked.cy - e.clientY + clicked.h,
+          minHeight,
+        );
+        if (currentHeight > minHeight) {
+          pane.style.height = currentHeight + "px";
+          pane.style.top = e.clientY + "px";
+        }
+      }
+
+      hintHide();
+
+      return;
+    }
+
+    if (clicked && clicked.isMoving) {
+      if (
+        b.top < FULLSCREEN_MARGINS ||
+        b.left < FULLSCREEN_MARGINS ||
+        b.right > window.innerWidth - FULLSCREEN_MARGINS ||
+        b.bottom > window.innerHeight - FULLSCREEN_MARGINS
+      ) {
+        // hintFull();
+        setBounds(ghostpane, 0, 0, window.innerWidth, window.innerHeight);
+        ghostpane.style.opacity = 0.2;
+      } else if (b.top < MARGINS) {
+        // hintTop();
+        setBounds(ghostpane, 0, 0, window.innerWidth, window.innerHeight / 2);
+        ghostpane.style.opacity = 0.2;
+      } else if (b.left < MARGINS) {
+        // hintLeft();
+        setBounds(ghostpane, 0, 0, window.innerWidth / 2, window.innerHeight);
+        ghostpane.style.opacity = 0.2;
+      } else if (b.right > rightScreenEdge) {
+        // hintRight();
+        setBounds(
+          ghostpane,
+          window.innerWidth / 2,
+          0,
+          window.innerWidth / 2,
+          window.innerHeight,
+        );
+        ghostpane.style.opacity = 0.2;
+      } else if (b.bottom > bottomScreenEdge) {
+        // hintBottom();
+        setBounds(
+          ghostpane,
+          0,
+          window.innerHeight / 2,
+          window.innerWidth,
+          window.innerWidth / 2,
+        );
+        ghostpane.style.opacity = 0.2;
+      } else {
+        hintHide();
+      }
+
+      if (preSnapped) {
+        setBounds(
+          pane,
+          e.clientX - preSnapped.width / 2,
+          e.clientY - Math.min(clicked.y, preSnapped.height),
+          preSnapped.width,
+          preSnapped.height,
+        );
+        return;
+      }
+
+      // moving
+      pane.style.top = e.clientY - clicked.y + "px";
+      pane.style.left = e.clientX - clicked.x + "px";
+
+      return;
+    }
+
+    // This code executes when mouse moves without clicking
+
+    // style cursor
+    if ((onRightEdge && onBottomEdge) || (onLeftEdge && onTopEdge)) {
+      pane.style.cursor = "nwse-resize";
+    } else if ((onRightEdge && onTopEdge) || (onBottomEdge && onLeftEdge)) {
+      pane.style.cursor = "nesw-resize";
+    } else if (onRightEdge || onLeftEdge) {
+      pane.style.cursor = "ew-resize";
+    } else if (onBottomEdge || onTopEdge) {
+      pane.style.cursor = "ns-resize";
+    } else if (canMove()) {
+      pane.style.cursor = "move";
+    } else {
+      pane.style.cursor = "default";
+    }
+  }
+
+  animate();
+
+  function onUp(e) {
+    calc(e);
+
+    if (clicked && clicked.isMoving) {
+      // Snap
+      var snapped = {
+        width: b.width,
+        height: b.height,
+      };
+
+      if (
+        b.top < FULLSCREEN_MARGINS ||
+        b.left < FULLSCREEN_MARGINS ||
+        b.right > window.innerWidth - FULLSCREEN_MARGINS ||
+        b.bottom > window.innerHeight - FULLSCREEN_MARGINS
+      ) {
+        // hintFull();
+        setBounds(pane, 0, 0, window.innerWidth, window.innerHeight);
+        preSnapped = snapped;
+      } else if (b.top < MARGINS) {
+        // hintTop();
+        setBounds(pane, 0, 0, window.innerWidth, window.innerHeight / 2);
+        preSnapped = snapped;
+      } else if (b.left < MARGINS) {
+        // hintLeft();
+        setBounds(pane, 0, 0, window.innerWidth / 2, window.innerHeight);
+        preSnapped = snapped;
+      } else if (b.right > rightScreenEdge) {
+        // hintRight();
+        setBounds(
+          pane,
+          window.innerWidth / 2,
+          0,
+          window.innerWidth / 2,
+          window.innerHeight,
+        );
+        preSnapped = snapped;
+      } else if (b.bottom > bottomScreenEdge) {
+        // hintBottom();
+        setBounds(
+          pane,
+          0,
+          window.innerHeight / 2,
+          window.innerWidth,
+          window.innerWidth / 2,
+        );
+        preSnapped = snapped;
+      } else {
+        preSnapped = null;
+      }
+
+      hintHide();
+    }
+
+    clicked = null;
+  }
+}

--- a/resources/js/components/map-01.js
+++ b/resources/js/components/map-01.js
@@ -1,0 +1,63 @@
+import jsVectorMap from "jsvectormap";
+import "jsvectormap/dist/maps/world";
+
+const map01 = () => {
+  const mapSelectorOne = document.querySelectorAll("#mapOne");
+
+  if (mapSelectorOne.length) {
+    const mapOne = new jsVectorMap({
+      selector: "#mapOne",
+      map: "world",
+      zoomButtons: false,
+
+      regionStyle: {
+        initial: {
+          fontFamily: "Outfit",
+          fill: "#D9D9D9",
+        },
+        hover: {
+          fillOpacity: 1,
+          fill: "#465fff",
+        },
+      },
+      markers: [
+        {
+          name: "Egypt",
+          coords: [26.8206, 30.8025],
+        },
+        {
+          name: "United Kingdom",
+          coords: [55.3781, 3.436],
+        },
+        {
+          name: "United States",
+          coords: [37.0902, -95.7129],
+        },
+      ],
+
+      markerStyle: {
+        initial: {
+          strokeWidth: 1,
+          fill: "#465fff",
+          fillOpacity: 1,
+          r: 4,
+        },
+        hover: {
+          fill: "#465fff",
+          fillOpacity: 1,
+        },
+        selected: {},
+        selectedHover: {},
+      },
+
+      onRegionTooltipShow: function (tooltip, code) {
+        if (code === "EG") {
+          tooltip.selector.innerHTML =
+            tooltip.text() + " <b>(Hello Russia)</b>";
+        }
+      },
+    });
+  }
+};
+
+export default map01;

--- a/resources/js/tailadmin.js
+++ b/resources/js/tailadmin.js
@@ -1,0 +1,117 @@
+import "jsvectormap/dist/jsvectormap.min.css";
+import "flatpickr/dist/flatpickr.min.css";
+import "dropzone/dist/dropzone.css";
+
+import Alpine from "alpinejs";
+import persist from "@alpinejs/persist";
+import flatpickr from "flatpickr";
+import Dropzone from "dropzone";
+
+import chart01 from "./components/charts/chart-01";
+import chart02 from "./components/charts/chart-02";
+import chart03 from "./components/charts/chart-03";
+import map01 from "./components/map-01";
+import "./components/calendar-init.js";
+import "./components/image-resize";
+
+Alpine.plugin(persist);
+window.Alpine = Alpine;
+Alpine.start();
+
+// Init flatpickr
+flatpickr(".datepicker", {
+  mode: "range",
+  static: true,
+  monthSelectorType: "static",
+  dateFormat: "M j, Y",
+  defaultDate: [new Date().setDate(new Date().getDate() - 6), new Date()],
+  prevArrow:
+    '<svg class="stroke-current" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15.25 6L9 12.25L15.25 18.5" stroke="" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+  nextArrow:
+    '<svg class="stroke-current" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.75 19L15 12.75L8.75 6.5" stroke="" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+  onReady: (selectedDates, dateStr, instance) => {
+    // eslint-disable-next-line no-param-reassign
+    instance.element.value = dateStr.replace("to", "-");
+    const customClass = instance.element.getAttribute("data-class");
+    instance.calendarContainer.classList.add(customClass);
+  },
+  onChange: (selectedDates, dateStr, instance) => {
+    // eslint-disable-next-line no-param-reassign
+    instance.element.value = dateStr.replace("to", "-");
+  },
+});
+
+// Init Dropzone
+const dropzoneArea = document.querySelectorAll("#demo-upload");
+
+if (dropzoneArea.length) {
+  let myDropzone = new Dropzone("#demo-upload", { url: "/file/post" });
+}
+
+// Document Loaded
+document.addEventListener("DOMContentLoaded", () => {
+  chart01();
+  chart02();
+  chart03();
+  map01();
+});
+
+// Get the current year
+const year = document.getElementById("year");
+if (year) {
+  year.textContent = new Date().getFullYear();
+}
+
+// For Copy//
+document.addEventListener("DOMContentLoaded", () => {
+  const copyInput = document.getElementById("copy-input");
+  if (copyInput) {
+    // Select the copy button and input field
+    const copyButton = document.getElementById("copy-button");
+    const copyText = document.getElementById("copy-text");
+    const websiteInput = document.getElementById("website-input");
+
+    // Event listener for the copy button
+    copyButton.addEventListener("click", () => {
+      // Copy the input value to the clipboard
+      navigator.clipboard.writeText(websiteInput.value).then(() => {
+        // Change the text to "Copied"
+        copyText.textContent = "Copied";
+
+        // Reset the text back to "Copy" after 2 seconds
+        setTimeout(() => {
+          copyText.textContent = "Copy";
+        }, 2000);
+      });
+    });
+  }
+});
+
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("search-input");
+  const searchButton = document.getElementById("search-button");
+
+  // Function to focus the search input
+  function focusSearchInput() {
+    searchInput.focus();
+  }
+
+  // Add click event listener to the search button
+  searchButton.addEventListener("click", focusSearchInput);
+
+  // Add keyboard event listener for Cmd+K (Mac) or Ctrl+K (Windows/Linux)
+  document.addEventListener("keydown", function (event) {
+    if ((event.metaKey || event.ctrlKey) && event.key === "k") {
+      event.preventDefault(); // Prevent the default browser behavior
+      focusSearchInput();
+    }
+  });
+
+  // Add keyboard event listener for "/" key
+  document.addEventListener("keydown", function (event) {
+    if (event.key === "/" && document.activeElement !== searchInput) {
+      event.preventDefault(); // Prevent the "/" character from being typed
+      focusSearchInput();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add the compiled TailAdmin stylesheet and supporting component scripts
- load the TailAdmin bundle from the existing Vite entrypoints and wire up chart/map/calendar helpers
- install the required third-party libraries that TailAdmin depends on

## Testing
- npm install
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de3e0aec448321bf5de9fcd5718ac4