### PR TITLE
Adopt TailAdmin layout across dashboard and modules

### DIFF
--- a/resources/views/admin/permissions/index.blade.php
+++ b/resources/views/admin/permissions/index.blade.php
@@ -1,53 +1,57 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        <h1 class="text-2xl font-semibold tracking-tight text-slate-900">
             {{ __('Permisos de módulos por rol') }}
-        </h2>
+        </h1>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
-                @if (session('status'))
-                    <div class="mb-4 rounded-md bg-green-50 p-4 text-sm text-green-700">{{ session('status') }}</div>
-                @endif
+    <section class="space-y-6">
+        @if (session('status'))
+            <x-tailadmin.alert type="success">
+                {{ session('status') }}
+            </x-tailadmin.alert>
+        @endif
 
-                <form method="POST" action="{{ route('admin.permissions.update') }}" class="space-y-8">
-                    @csrf
-                    @method('PUT')
+        <x-tailadmin.section-card
+            :title="__('Visibilidad de módulos')"
+            :description="__('Define qué módulos pueden visualizar los usuarios según su rol.')"
+        >
+            <form method="POST" action="{{ route('admin.permissions.update') }}" class="space-y-6">
+                @csrf
+                @method('PUT')
 
-                    @foreach ($roles as $role)
-                        <div class="border border-gray-200 rounded-lg p-4">
-                            <h3 class="text-lg font-semibold text-gray-800 mb-4">{{ $role->name }}</h3>
-                            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                                @foreach ($modules as $moduleKey => $module)
-                                    @php
-                                        $viewPermission = $module['permissions']['view'] ?? null;
-                                    @endphp
-                                    @continue(!$viewPermission)
-                                    <label class="flex items-start space-x-2">
-                                        <input
-                                            type="checkbox"
-                                            name="roles[{{ $role->id }}][]"
-                                            value="{{ $viewPermission }}"
-                                            class="mt-1 rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
-                                            {{ $role->permissions->contains('name', $viewPermission) ? 'checked' : '' }}
-                                        >
-                                        <span>
-                                            <span class="block font-medium text-gray-700">{{ $module['label'] }}</span>
-                                            <span class="block text-xs text-gray-500">{{ $module['route'] ?? '' }}</span>
-                                        </span>
-                                    </label>
-                                @endforeach
-                            </div>
+                @foreach ($roles as $role)
+                    <div class="rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm">
+                        <h3 class="text-lg font-semibold text-slate-800">{{ $role->name }}</h3>
+                        <div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                            @foreach ($modules as $moduleKey => $module)
+                                @php
+                                    $viewPermission = $module['permissions']['view'] ?? null;
+                                @endphp
+                                @continue(!$viewPermission)
+
+                                <label class="flex items-start gap-3 rounded-xl border border-slate-200 bg-white/70 p-3 text-sm text-slate-600 shadow-sm">
+                                    <input
+                                        type="checkbox"
+                                        name="roles[{{ $role->id }}][]"
+                                        value="{{ $viewPermission }}"
+                                        class="mt-1 rounded border-slate-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
+                                        {{ $role->permissions->contains('name', $viewPermission) ? 'checked' : '' }}
+                                    >
+                                    <span>
+                                        <span class="block font-medium text-slate-800">{{ $module['label'] }}</span>
+                                        <span class="block text-xs text-slate-500">{{ $module['route'] ?? '' }}</span>
+                                    </span>
+                                </label>
+                            @endforeach
                         </div>
-                    @endforeach
-
-                    <div class="flex justify-end">
-                        <x-primary-button>{{ __('Guardar cambios') }}</x-primary-button>
                     </div>
-                </form>
-            </div>
-        </div>
-    </div>
+                @endforeach
+
+                <div class="flex justify-end">
+                    <x-primary-button>{{ __('Guardar cambios') }}</x-primary-button>
+                </div>
+            </form>
+        </x-tailadmin.section-card>
+    </section>
 </x-app-layout>

--- a/resources/views/admin/roles/index.blade.php
+++ b/resources/views/admin/roles/index.blade.php
@@ -1,69 +1,70 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        <h1 class="text-2xl font-semibold tracking-tight text-slate-900">
             {{ __('Asignar permisos a roles') }}
-        </h2>
+        </h1>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
-                @if (session('status'))
-                    <div class="mb-4 text-green-600">{{ session('status') }}</div>
-                @endif
+    <section class="space-y-6">
+        @if (session('status'))
+            <x-tailadmin.alert type="success">
+                {{ session('status') }}
+            </x-tailadmin.alert>
+        @endif
 
-                <form method="POST" action="{{ route('admin.roles.permissions.update') }}">
-                    @csrf
-                    @method('PUT')
+        <x-tailadmin.section-card
+            :title="__('Configuración de permisos')"
+            :description="__('Selecciona los permisos que corresponden a cada rol disponible en la plataforma.')"
+        >
+            <form method="POST" action="{{ route('admin.roles.permissions.update') }}" class="space-y-8">
+                @csrf
+                @method('PUT')
 
-                    <div class="space-y-8">
-                        @foreach ($roles as $role)
-                            <div>
-                                <h3 class="text-lg font-semibold text-gray-700 mb-4">{{ $role->name }}</h3>
-                                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                                    @foreach ($modules as $moduleKey => $module)
-                                        @php
-                                            $permissions = $module['permissions'] ?? [];
-                                            $permissionLabels = [
-                                                'view' => __('Ver'),
-                                                'manage' => __('Gestionar'),
-                                            ];
-                                        @endphp
-                                        <div class="border border-gray-200 rounded-lg p-4">
-                                            <div class="flex justify-between items-start">
-                                                <div>
-                                                    <span class="block font-medium text-gray-800">{{ $module['label'] }}</span>
-                                                    @isset($module['route'])
-                                                        <span class="block text-xs text-gray-500">{{ $module['route'] }}</span>
-                                                    @endisset
-                                                </div>
-                                            </div>
-                                            <div class="mt-3 space-y-2">
-                                                @foreach ($permissions as $type => $permissionName)
-                                                    <label class="flex items-center space-x-2 text-sm text-gray-700">
-                                                        <input
-                                                            type="checkbox"
-                                                            name="roles[{{ $role->id }}][]"
-                                                            value="{{ $permissionName }}"
-                                                            class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
-                                                            {{ $role->permissions->contains('name', $permissionName) ? 'checked' : '' }}
-                                                        >
-                                                        <span>{{ $permissionLabels[$type] ?? ucfirst($type) }}</span>
-                                                    </label>
-                                                @endforeach
-                                            </div>
-                                        </div>
-                                    @endforeach
+                @foreach ($roles as $role)
+                    <div class="space-y-4">
+                        <h3 class="text-lg font-semibold text-slate-800">{{ $role->name }}</h3>
+                        <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                            @foreach ($modules as $moduleKey => $module)
+                                @php
+                                    $permissions = $module['permissions'] ?? [];
+                                    $permissionLabels = [
+                                        'view' => __('Ver'),
+                                        'manage' => __('Gestionar'),
+                                    ];
+                                @endphp
+
+                                <div class="rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm">
+                                    <div class="flex flex-col gap-1">
+                                        <span class="text-sm font-semibold text-slate-900">{{ $module['label'] }}</span>
+                                        @isset($module['route'])
+                                            <span class="text-xs text-slate-500">{{ $module['route'] }}</span>
+                                        @endisset
+                                    </div>
+
+                                    <div class="mt-4 space-y-2">
+                                        @foreach ($permissions as $type => $permissionName)
+                                            <label class="flex items-center gap-2 text-sm text-slate-600">
+                                                <input
+                                                    type="checkbox"
+                                                    name="roles[{{ $role->id }}][]"
+                                                    value="{{ $permissionName }}"
+                                                    class="rounded border-slate-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
+                                                    {{ $role->permissions->contains('name', $permissionName) ? 'checked' : '' }}
+                                                >
+                                                <span>{{ $permissionLabels[$type] ?? ucfirst($type) }}</span>
+                                            </label>
+                                        @endforeach
+                                    </div>
                                 </div>
-                            </div>
-                        @endforeach
+                            @endforeach
+                        </div>
                     </div>
+                @endforeach
 
-                    <div class="mt-6">
-                        <x-primary-button>{{ __('Guardar cambios') }}</x-primary-button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
+                <div>
+                    <x-primary-button>{{ __('Guardar cambios') }}</x-primary-button>
+                </div>
+            </form>
+        </x-tailadmin.section-card>
+    </section>
 </x-app-layout>

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -1,58 +1,66 @@
 <x-app-layout>
     <x-slot name="header">
-        <div class="flex items-center justify-between">
-            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h1 class="text-2xl font-semibold tracking-tight text-slate-900">
                 {{ __('Usuarios') }}
-            </h2>
-            <a href="{{ route('admin.users.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:ring ring-indigo-300 disabled:opacity-25 transition ease-in-out duration-150">
+            </h1>
+            <a href="{{ route('admin.users.create') }}"
+                class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
                 {{ __('Crear usuario') }}
             </a>
         </div>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
-                @if (session('status'))
-                    <div class="mb-4 text-green-600">{{ session('status') }}</div>
-                @endif
+    <section class="space-y-6">
+        @if (session('status'))
+            <x-tailadmin.alert type="success">
+                {{ session('status') }}
+            </x-tailadmin.alert>
+        @endif
 
-                <div class="overflow-x-auto">
-                    <table class="min-w-full divide-y divide-gray-200">
-                        <thead class="bg-gray-50">
-                            <tr>
-                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Nombre') }}</th>
-                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Correo') }}</th>
-                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Rol') }}</th>
-                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Almacén') }}</th>
-                                <th class="px-6 py-3"></th>
-                            </tr>
-                        </thead>
-                        <tbody class="bg-white divide-y divide-gray-200">
-                            @forelse ($users as $user)
-                                <tr>
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $user->name }}</td>
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $user->email }}</td>
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $user->roles->pluck('name')->implode(', ') ?: __('Sin rol') }}</td>
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ optional($user->almacen)->nombre ?: __('N/A') }}</td>
-                                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
-                                        <a href="{{ route('admin.users.edit', $user) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Editar') }}</a>
-                                        <a href="{{ route('admin.users.permissions.edit', $user) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Permisos') }}</a>
-                                    </td>
-                                </tr>
-                            @empty
-                                <tr>
-                                    <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No hay usuarios registrados.') }}</td>
-                                </tr>
-                            @endforelse
-                        </tbody>
-                    </table>
-                </div>
+        <x-tailadmin.table-card
+            :title="__('Usuarios registrados')"
+            :description="__('Administra las cuentas, roles y almacenes asignados en el sistema.')"
+            :headers="[
+                ['label' => __('Nombre')],
+                ['label' => __('Correo')],
+                ['label' => __('Rol')],
+                ['label' => __('Almacén')],
+                ['label' => ''],
+            ]"
+        >
+            @forelse ($users as $user)
+                <tr class="odd:bg-white even:bg-slate-50">
+                    <td class="whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-900">{{ $user->name }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">{{ $user->email }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">{{ $user->roles->pluck('name')->implode(', ') ?: __('Sin rol') }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">{{ optional($user->almacen)->nombre ?: __('N/A') }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-right text-sm">
+                        <div class="flex items-center justify-end gap-2">
+                            <a href="{{ route('admin.users.edit', $user) }}"
+                                class="inline-flex items-center gap-1 rounded-lg border border-indigo-200 bg-white px-3 py-1.5 text-sm font-medium text-indigo-600 shadow-sm transition hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                                {{ __('Editar') }}
+                            </a>
+                            <a href="{{ route('admin.users.permissions.edit', $user) }}"
+                                class="inline-flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2">
+                                {{ __('Permisos') }}
+                            </a>
+                        </div>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="5" class="px-6 py-4 text-center text-sm text-slate-500">
+                        {{ __('No hay usuarios registrados.') }}
+                    </td>
+                </tr>
+            @endforelse
 
-                <div class="mt-4">
+            @if ($users->hasPages())
+                <x-slot:footer>
                     {{ $users->links() }}
-                </div>
-            </div>
-        </div>
-    </div>
+                </x-slot:footer>
+            @endif
+        </x-tailadmin.table-card>
+    </section>
 </x-app-layout>

--- a/resources/views/almacen/pedidos/index.blade.php
+++ b/resources/views/almacen/pedidos/index.blade.php
@@ -1,54 +1,64 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        <h1 class="text-2xl font-semibold tracking-tight text-slate-900">
             {{ __('Pedidos asignados a mi almacén') }}
-        </h2>
+        </h1>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900 space-y-4">
-                    <div class="overflow-x-auto">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-gray-50">
-                                <tr>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Código') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Tienda') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Monto total') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Estado pedido') }}</th>
-                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Acciones') }}</th>
-                                </tr>
-                            </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
-                                @forelse ($pedidos as $pedido)
-                                    <tr>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">#{{ $pedido->id }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $pedido->tienda?->nombre }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">S/ {{ number_format($pedido->monto_total, 2) }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm">
-                                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold {{ $pedido->estado_pedido === \App\Models\Pedido::ESTADO_PEDIDO_ENTREGADO ? 'bg-green-100 text-green-800' : ($pedido->estado_pedido === \App\Models\Pedido::ESTADO_PEDIDO_ANULADO ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-800') }}">
-                                                {{ ucwords(str_replace('_', ' ', $pedido->estado_pedido)) }}
-                                            </span>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                            <a href="{{ route('almacen.pedidos.show', $pedido) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Ver detalle') }}</a>
-                                        </td>
-                                    </tr>
-                                @empty
-                                    <tr>
-                                        <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No hay pedidos asignados a este almacén.') }}</td>
-                                    </tr>
-                                @endforelse
-                            </tbody>
-                        </table>
-                    </div>
+    <section class="space-y-6">
+        @php
+            $estadoPedidoStyles = [
+                \App\Models\Pedido::ESTADO_PEDIDO_ENTREGADO => 'bg-emerald-50 text-emerald-600 ring-emerald-100',
+                \App\Models\Pedido::ESTADO_PEDIDO_EN_CURSO => 'bg-sky-50 text-sky-600 ring-sky-100',
+                \App\Models\Pedido::ESTADO_PEDIDO_PENDIENTE => 'bg-amber-50 text-amber-600 ring-amber-100',
+                \App\Models\Pedido::ESTADO_PEDIDO_ANULADO => 'bg-rose-50 text-rose-600 ring-rose-100',
+            ];
+        @endphp
 
-                    <div>
-                        {{ $pedidos->links() }}
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+        <x-tailadmin.table-card
+            :title="__('Pedidos en seguimiento')"
+            :description="__('Listado de pedidos asignados al almacén para control y despacho.')"
+            :headers="[
+                ['label' => __('Código')],
+                ['label' => __('Tienda')],
+                ['label' => __('Monto total')],
+                ['label' => __('Estado pedido')],
+                ['label' => __('Acciones'), 'class' => 'text-right'],
+            ]"
+        >
+            @forelse ($pedidos as $pedido)
+                <tr class="odd:bg-white even:bg-slate-50">
+                    <td class="whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-900">#{{ $pedido->id }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">{{ $pedido->tienda?->nombre }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">S/ {{ number_format($pedido->monto_total, 2) }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm">
+                        @php
+                            $estadoPedidoClass = $estadoPedidoStyles[$pedido->estado_pedido] ?? 'bg-slate-50 text-slate-600 ring-slate-100';
+                        @endphp
+                        <span class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ring-inset {{ $estadoPedidoClass }}">
+                            {{ ucwords(str_replace('_', ' ', $pedido->estado_pedido)) }}
+                        </span>
+                    </td>
+                    <td class="whitespace-nowrap px-6 py-4 text-right text-sm">
+                        <a href="{{ route('almacen.pedidos.show', $pedido) }}"
+                            class="inline-flex items-center gap-1 rounded-lg border border-indigo-200 bg-white px-3 py-1.5 text-sm font-medium text-indigo-600 shadow-sm transition hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                            {{ __('Ver detalle') }}
+                        </a>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="5" class="px-6 py-4 text-center text-sm text-slate-500">
+                        {{ __('No hay pedidos asignados a este almacén.') }}
+                    </td>
+                </tr>
+            @endforelse
+
+            @if ($pedidos->hasPages())
+                <x-slot:footer>
+                    {{ $pedidos->links() }}
+                </x-slot:footer>
+            @endif
+        </x-tailadmin.table-card>
+    </section>
 </x-app-layout>

--- a/resources/views/categorias/index.blade.php
+++ b/resources/views/categorias/index.blade.php
@@ -1,88 +1,77 @@
 <x-app-layout>
     <x-slot name="header">
-        <div class="flex items-center justify-between">
-            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h1 class="text-2xl font-semibold tracking-tight text-slate-900">
                 {{ __('Categorías') }}
-            </h2>
+            </h1>
             @can('manage categorias')
                 <a href="{{ route('categorias.create') }}"
-                    class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                    class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
                     {{ __('Agregar categoría') }}
                 </a>
             @endcan
         </div>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900 space-y-4">
-                    @if (session('status'))
-                        <div class="rounded-md bg-green-50 p-4 text-sm text-green-700">{{ session('status') }}</div>
-                    @endif
+    <section class="space-y-6">
+        @if (session('status'))
+            <x-tailadmin.alert type="success">
+                {{ session('status') }}
+            </x-tailadmin.alert>
+        @endif
 
-                    <div class="overflow-x-auto">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-gray-50">
-                                <tr>
-                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                        {{ __('Nombre') }}
-                                    </th>
-                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                        {{ __('Fecha de creación') }}
-                                    </th>
-                                    <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                        {{ __('Acciones') }}
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
-                                @forelse ($categorias as $categoria)
-                                    <tr>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                                            <a href="{{ route('categorias.show', $categoria) }}" class="text-indigo-600 hover:text-indigo-900">
-                                                {{ $categoria->nombre }}
-                                            </a>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                                            {{ $categoria->created_at?->format('d/m/Y H:i') }}
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
-                                            @can('manage categorias')
-                                                <div class="flex items-center justify-end gap-2">
-                                                    <a href="{{ route('categorias.edit', $categoria) }}"
-                                                        class="inline-flex items-center rounded-md border border-indigo-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-indigo-600 transition duration-150 ease-in-out hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-                                                        {{ __('Actualizar') }}
-                                                    </a>
-                                                    <form action="{{ route('categorias.destroy', $categoria) }}" method="POST"
-                                                        onsubmit="return confirm('{{ __('¿Eliminar esta categoría?') }}');">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type="submit"
-                                                            class="inline-flex items-center rounded-md border border-red-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-red-600 transition duration-150 ease-in-out hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
-                                                            {{ __('Eliminar') }}
-                                                        </button>
-                                                    </form>
-                                                </div>
-                                            @endcan
-                                        </td>
-                                    </tr>
-                                @empty
-                                    <tr>
-                                        <td colspan="3" class="px-6 py-4 text-center text-sm text-gray-500">
-                                            {{ __('No se encontraron categorías.') }}
-                                        </td>
-                                    </tr>
-                                @endforelse
-                            </tbody>
-                        </table>
-                    </div>
+        <x-tailadmin.table-card
+            :title="__('Categorías registradas')"
+            :description="__('Organiza el catálogo de productos por categorías.')"
+            :headers="[
+                ['label' => __('Nombre')],
+                ['label' => __('Fecha de creación')],
+                ['label' => __('Acciones'), 'class' => 'text-right'],
+            ]"
+        >
+            @forelse ($categorias as $categoria)
+                <tr class="odd:bg-white even:bg-slate-50">
+                    <td class="whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-900">
+                        <a href="{{ route('categorias.show', $categoria) }}" class="text-indigo-600 transition hover:text-indigo-500">
+                            {{ $categoria->nombre }}
+                        </a>
+                    </td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">
+                        {{ $categoria->created_at?->format('d/m/Y H:i') }}
+                    </td>
+                    <td class="whitespace-nowrap px-6 py-4 text-right text-sm">
+                        @can('manage categorias')
+                            <div class="flex items-center justify-end gap-2">
+                                <a href="{{ route('categorias.edit', $categoria) }}"
+                                    class="inline-flex items-center gap-2 rounded-lg border border-indigo-200 bg-white px-3 py-1.5 text-sm font-medium text-indigo-600 shadow-sm transition hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                                    {{ __('Actualizar') }}
+                                </a>
+                                <form action="{{ route('categorias.destroy', $categoria) }}" method="POST"
+                                    onsubmit="return confirm('{{ __('¿Eliminar esta categoría?') }}');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit"
+                                        class="inline-flex items-center gap-2 rounded-lg border border-rose-200 bg-white px-3 py-1.5 text-sm font-medium text-rose-600 shadow-sm transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-offset-2">
+                                        {{ __('Eliminar') }}
+                                    </button>
+                                </form>
+                            </div>
+                        @endcan
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="3" class="px-6 py-4 text-center text-sm text-slate-500">
+                        {{ __('No se encontraron categorías.') }}
+                    </td>
+                </tr>
+            @endforelse
 
-                    <div>
-                        {{ $categorias->links() }}
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+            @if ($categorias->hasPages())
+                <x-slot:footer>
+                    {{ $categorias->links() }}
+                </x-slot:footer>
+            @endif
+        </x-tailadmin.table-card>
+    </section>
 </x-app-layout>

--- a/resources/views/cierres/index.blade.php
+++ b/resources/views/cierres/index.blade.php
@@ -1,74 +1,77 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        <h1 class="text-2xl font-semibold tracking-tight text-slate-900">
             {{ __('Cierre diario de almacenes') }}
-        </h2>
+        </h1>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900">
-                    <form method="GET" class="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
-                        <div>
-                            <x-input-label for="fecha" value="{{ __('Fecha') }}" />
-                            <x-text-input id="fecha" type="date" name="fecha" class="mt-1 block w-full" :value="$fecha" />
-                        </div>
-                        <div>
-                            <x-input-label for="almacen_id" value="{{ __('Almacén') }}" />
-                            <select id="almacen_id" name="almacen_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                                <option value="">{{ __('Todos') }}</option>
-                                @foreach ($almacenes as $id => $nombre)
-                                    <option value="{{ $id }}" @selected($almacenId == $id)>{{ $nombre }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div class="md:col-span-2 flex space-x-2">
-                            <x-primary-button class="self-end">{{ __('Filtrar') }}</x-primary-button>
-                            <a href="{{ route('supervisor.cierres.index') }}" class="self-end inline-flex items-center px-4 py-2 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-300 focus:outline-none focus:border-gray-400 focus:ring ring-gray-200 transition ease-in-out duration-150">{{ __('Limpiar') }}</a>
-                        </div>
-                    </form>
+    <section class="space-y-6">
+        <x-tailadmin.section-card
+            :title="__('Filtros de búsqueda')"
+            :description="__('Define la fecha y el almacén para consultar los cierres generados.')"
+        >
+            <form method="GET" class="grid grid-cols-1 items-end gap-4 md:grid-cols-4">
+                <div>
+                    <x-input-label for="fecha" value="{{ __('Fecha') }}" />
+                    <x-text-input id="fecha" type="date" name="fecha" class="mt-1 block w-full" :value="$fecha" />
                 </div>
-            </div>
-
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900 space-y-4">
-                    <div class="overflow-x-auto">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-gray-50">
-                                <tr>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Fecha') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Almacén') }}</th>
-                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Total ventas') }}</th>
-                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Total pagado') }}</th>
-                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Saldo pendiente') }}</th>
-                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Vuelto') }}</th>
-                                </tr>
-                            </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
-                                @forelse ($cierres as $cierre)
-                                    <tr>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ \Carbon\Carbon::parse($cierre->fecha)->format('d/m/Y') }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $cierre->almacen_nombre ?? __('Sin almacén') }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">S/ {{ number_format($cierre->total_monto, 2) }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">S/ {{ number_format($cierre->total_pagado, 2) }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">S/ {{ number_format($cierre->total_pendiente, 2) }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">S/ {{ number_format($cierre->total_vuelto, 2) }}</td>
-                                    </tr>
-                                @empty
-                                    <tr>
-                                        <td colspan="6" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No hay información disponible para los filtros seleccionados.') }}</td>
-                                    </tr>
-                                @endforelse
-                            </tbody>
-                        </table>
-                    </div>
-
-                    <div>
-                        {{ $cierres->appends(request()->query())->links() }}
-                    </div>
+                <div>
+                    <x-input-label for="almacen_id" value="{{ __('Almacén') }}" />
+                    <select
+                        id="almacen_id"
+                        name="almacen_id"
+                        class="mt-1 block w-full rounded-xl border border-slate-300 bg-white/95 px-3 py-2 text-sm text-slate-700 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+                    >
+                        <option value="">{{ __('Todos') }}</option>
+                        @foreach ($almacenes as $id => $nombre)
+                            <option value="{{ $id }}" @selected($almacenId == $id)>{{ $nombre }}</option>
+                        @endforeach
+                    </select>
                 </div>
-            </div>
-        </div>
-    </div>
+                <div class="md:col-span-2 flex flex-wrap items-center gap-3">
+                    <x-primary-button>{{ __('Filtrar') }}</x-primary-button>
+                    <a href="{{ route('supervisor.cierres.index') }}"
+                        class="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2">
+                        {{ __('Limpiar') }}
+                    </a>
+                </div>
+            </form>
+        </x-tailadmin.section-card>
+
+        <x-tailadmin.table-card
+            :title="__('Resumen de cierres')"
+            :description="__('Detalle consolidado de ventas y cobranzas por almacén y fecha.')"
+            :headers="[
+                ['label' => __('Fecha')],
+                ['label' => __('Almacén')],
+                ['label' => __('Total ventas'), 'class' => 'text-right'],
+                ['label' => __('Total pagado'), 'class' => 'text-right'],
+                ['label' => __('Saldo pendiente'), 'class' => 'text-right'],
+                ['label' => __('Vuelto'), 'class' => 'text-right'],
+            ]"
+        >
+            @forelse ($cierres as $cierre)
+                <tr class="odd:bg-white even:bg-slate-50">
+                    <td class="whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-900">{{ \Carbon\Carbon::parse($cierre->fecha)->format('d/m/Y') }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">{{ $cierre->almacen_nombre ?? __('Sin almacén') }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-right text-sm text-slate-700">S/ {{ number_format($cierre->total_monto, 2) }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-right text-sm text-slate-700">S/ {{ number_format($cierre->total_pagado, 2) }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-right text-sm text-slate-700">S/ {{ number_format($cierre->total_pendiente, 2) }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-right text-sm text-slate-700">S/ {{ number_format($cierre->total_vuelto, 2) }}</td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="6" class="px-6 py-4 text-center text-sm text-slate-500">
+                        {{ __('No hay información disponible para los filtros seleccionados.') }}
+                    </td>
+                </tr>
+            @endforelse
+
+            @if ($cierres->hasPages())
+                <x-slot:footer>
+                    {{ $cierres->appends(request()->query())->links() }}
+                </x-slot:footer>
+            @endif
+        </x-tailadmin.table-card>
+    </section>
 </x-app-layout>

--- a/resources/views/components/tailadmin/alert.blade.php
+++ b/resources/views/components/tailadmin/alert.blade.php
@@ -1,0 +1,51 @@
+@props([
+    'type' => 'info',
+    'title' => null,
+])
+
+@php
+    $palettes = [
+        'info' => [
+            'container' => 'border-sky-200 bg-sky-50 text-sky-700',
+            'icon' => 'text-sky-500',
+        ],
+        'success' => [
+            'container' => 'border-emerald-200 bg-emerald-50 text-emerald-700',
+            'icon' => 'text-emerald-500',
+        ],
+        'warning' => [
+            'container' => 'border-amber-200 bg-amber-50 text-amber-700',
+            'icon' => 'text-amber-500',
+        ],
+        'danger' => [
+            'container' => 'border-rose-200 bg-rose-50 text-rose-700',
+            'icon' => 'text-rose-500',
+        ],
+    ];
+
+    $palette = $palettes[$type] ?? $palettes['info'];
+@endphp
+
+<div
+    {{
+        $attributes->merge([
+            'class' => 'flex items-start gap-3 rounded-2xl border px-4 py-3 text-sm shadow-sm '.$palette['container'],
+        ])
+    }}
+>
+    <div class="mt-0.5">
+        <svg class="h-5 w-5 {{ $palette['icon'] }}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+            stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0 3.75h.008v.008H12V16.5zm9-4.5a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+    </div>
+    <div class="space-y-1">
+        @if ($title)
+            <p class="font-semibold">{{ $title }}</p>
+        @endif
+
+        <div class="text-sm leading-relaxed">
+            {{ $slot }}
+        </div>
+    </div>
+</div>

--- a/resources/views/components/tailadmin/data-table-card.blade.php
+++ b/resources/views/components/tailadmin/data-table-card.blade.php
@@ -5,26 +5,43 @@
     'emptyMessage' => 'No hay datos disponibles.',
 ])
 
+@php
+    use Illuminate\\View\\ComponentSlot;
+
+    $hasDescription = ! $slot->isEmpty();
+    $hasActions = isset($actions) && $actions instanceof ComponentSlot && trim($actions->toHtml()) !== '';
+@endphp
+
 <div
     {{
         $attributes->merge([
-            'class' => 'flex flex-col rounded-2xl border border-slate-200 bg-white shadow-sm',
+            'class' => 'overflow-hidden rounded-2xl border border-slate-200 bg-white/95 shadow-sm',
         ])
     }}
 >
-    <div class="border-b border-slate-200 px-6 py-5">
-        @if ($title)
-            <h3 class="text-lg font-semibold text-slate-900">{{ $title }}</h3>
-        @endif
+    @if ($title || $hasDescription || $hasActions)
+        <div class="flex flex-col gap-4 border-b border-slate-200 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+            <div class="space-y-1">
+                @if ($title)
+                    <h3 class="text-lg font-semibold text-slate-900">{{ $title }}</h3>
+                @endif
 
-        @if (! $slot->isEmpty())
-            <p class="mt-2 text-sm text-slate-500">
-                {{ $slot }}
-            </p>
-        @endif
-    </div>
+                @if ($hasDescription)
+                    <p class="text-sm text-slate-500">
+                        {{ $slot }}
+                    </p>
+                @endif
+            </div>
 
-    <div class="px-2 pb-6 pt-4 sm:px-4">
+            @if ($hasActions)
+                <div class="flex flex-wrap items-center gap-2">
+                    {{ $actions }}
+                </div>
+            @endif
+        </div>
+    @endif
+
+    <div class="px-4 pb-6 pt-4 sm:px-6">
         <div class="overflow-hidden">
             <div class="max-w-full overflow-x-auto">
                 <table class="min-w-full divide-y divide-slate-200 text-left text-sm">

--- a/resources/views/components/tailadmin/metric-card.blade.php
+++ b/resources/views/components/tailadmin/metric-card.blade.php
@@ -5,24 +5,24 @@
     'icon' => null,
     'badge' => null,
     'badgeColor' => 'primary',
-    'iconClasses' => 'bg-indigo-100 text-indigo-600',
+    'iconClasses' => 'bg-indigo-50 text-indigo-600',
 ])
 
 @php
-    use Illuminate\View\ComponentSlot;
+    use Illuminate\\View\\ComponentSlot;
 
     $iconContent = $icon instanceof ComponentSlot ? $icon->toHtml() : $icon;
-    $hasIcon = filled(trim((string) $iconContent ?? ''));
+    $hasIcon = filled(trim((string) ($iconContent ?? '')));
 
     $badgeContent = $badge instanceof ComponentSlot ? $badge->toHtml() : $badge;
-    $hasBadge = filled(trim((string) $badgeContent ?? ''));
+    $hasBadge = filled(trim((string) ($badgeContent ?? '')));
 
     $badgePalettes = [
-        'primary' => 'bg-indigo-100 text-indigo-600',
-        'success' => 'bg-emerald-100 text-emerald-600',
-        'warning' => 'bg-amber-100 text-amber-600',
-        'danger' => 'bg-rose-100 text-rose-600',
-        'info' => 'bg-sky-100 text-sky-600',
+        'primary' => 'bg-indigo-50 text-indigo-600 ring-indigo-100',
+        'success' => 'bg-emerald-50 text-emerald-600 ring-emerald-100',
+        'warning' => 'bg-amber-50 text-amber-600 ring-amber-100',
+        'danger' => 'bg-rose-50 text-rose-600 ring-rose-100',
+        'info' => 'bg-sky-50 text-sky-600 ring-sky-100',
     ];
 
     $badgeClasses = $badgePalettes[$badgeColor] ?? $badgePalettes['primary'];
@@ -31,30 +31,30 @@
 <div
     {{
         $attributes->merge([
-            'class' => 'group rounded-2xl border border-slate-200 bg-white/95 p-6 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md',
+            'class' => 'relative overflow-hidden rounded-2xl border border-slate-200 bg-white/95 p-6 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md',
         ])
     }}
 >
     <div class="flex items-start justify-between gap-4">
         <div class="flex items-center gap-4">
             @if ($hasIcon)
-                <div class="flex h-14 w-14 items-center justify-center rounded-full {{ $iconClasses }}">
+                <div class="flex h-14 w-14 items-center justify-center rounded-2xl {{ $iconClasses }}">
                     {!! $iconContent !!}
                 </div>
             @endif
 
-            <div class="flex-1 space-y-2">
+            <div class="space-y-2">
                 @if ($title)
                     <p class="text-sm font-medium text-slate-500">{{ $title }}</p>
                 @endif
 
                 <div class="flex flex-wrap items-center gap-3">
                     @isset($value)
-                        <p class="text-2xl font-semibold text-slate-900">{{ $value }}</p>
+                        <p class="text-3xl font-semibold tracking-tight text-slate-900">{{ $value }}</p>
                     @endisset
 
                     @if ($hasBadge)
-                        <span class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold {{ $badgeClasses }}">
+                        <span class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ring-inset {{ $badgeClasses }}">
                             {!! $badgeContent !!}
                         </span>
                     @endif

--- a/resources/views/components/tailadmin/section-card.blade.php
+++ b/resources/views/components/tailadmin/section-card.blade.php
@@ -1,0 +1,49 @@
+@props([
+    'title' => null,
+    'description' => null,
+])
+
+@php
+    use Illuminate\\View\\ComponentSlot;
+
+    $hasActions = isset($actions) && $actions instanceof ComponentSlot && trim($actions->toHtml()) !== '';
+    $hasFooter = isset($footer) && $footer instanceof ComponentSlot && trim($footer->toHtml()) !== '';
+@endphp
+
+<div
+    {{
+        $attributes->merge([
+            'class' => 'rounded-2xl border border-slate-200 bg-white/95 p-6 shadow-sm',
+        ])
+    }}
+>
+    @if ($title || filled($description) || $hasActions)
+        <div class="flex flex-col gap-4 border-b border-slate-200 pb-5 sm:flex-row sm:items-center sm:justify-between">
+            <div class="space-y-1">
+                @if ($title)
+                    <h3 class="text-lg font-semibold text-slate-900">{{ $title }}</h3>
+                @endif
+
+                @if (filled($description))
+                    <p class="text-sm text-slate-500">{{ $description }}</p>
+                @endif
+            </div>
+
+            @if ($hasActions)
+                <div class="flex flex-wrap items-center gap-2">
+                    {{ $actions }}
+                </div>
+            @endif
+        </div>
+    @endif
+
+    <div class="mt-5 space-y-6">
+        {{ $slot }}
+    </div>
+
+    @if ($hasFooter)
+        <div class="mt-6 border-t border-slate-200 pt-4">
+            {{ $footer }}
+        </div>
+    @endif
+</div>

--- a/resources/views/components/tailadmin/table-card.blade.php
+++ b/resources/views/components/tailadmin/table-card.blade.php
@@ -1,0 +1,70 @@
+@props([
+    'title' => null,
+    'description' => null,
+    'headers' => [],
+])
+
+@php
+    use Illuminate\\View\\ComponentSlot;
+
+    $hasDescription = filled($description);
+    $hasActions = isset($actions) && $actions instanceof ComponentSlot && trim($actions->toHtml()) !== '';
+    $hasFooter = isset($footer) && $footer instanceof ComponentSlot && trim($footer->toHtml()) !== '';
+@endphp
+
+<div
+    {{
+        $attributes->merge([
+            'class' => 'overflow-hidden rounded-2xl border border-slate-200 bg-white/95 shadow-sm',
+        ])
+    }}
+>
+    @if ($title || $hasDescription || $hasActions)
+        <div class="flex flex-col gap-4 border-b border-slate-200 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+            <div class="space-y-1">
+                @if ($title)
+                    <h3 class="text-lg font-semibold text-slate-900">{{ $title }}</h3>
+                @endif
+
+                @if ($hasDescription)
+                    <p class="text-sm text-slate-500">{{ $description }}</p>
+                @endif
+            </div>
+
+            @if ($hasActions)
+                <div class="flex flex-wrap items-center gap-2">
+                    {{ $actions }}
+                </div>
+            @endif
+        </div>
+    @endif
+
+    <div class="px-4 pb-6 pt-4 sm:px-6">
+        <div class="overflow-hidden">
+            <div class="max-w-full overflow-x-auto">
+                <table class="min-w-full divide-y divide-slate-200 text-left text-sm">
+                    @if (! empty($headers))
+                        <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                            <tr>
+                                @foreach ($headers as $header)
+                                    <th scope="col" class="whitespace-nowrap px-6 py-3 {{ $header['class'] ?? 'text-left' }}">
+                                        {{ $header['label'] }}
+                                    </th>
+                                @endforeach
+                            </tr>
+                        </thead>
+                    @endif
+                    <tbody class="divide-y divide-slate-200 bg-white">
+                        {{ $slot }}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    @if ($hasFooter)
+        <div class="border-t border-slate-200 bg-white/90 px-6 py-4">
+            {{ $footer }}
+        </div>
+    @endif
+</div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,12 +1,12 @@
 <x-app-layout>
     <x-slot name="header">
-        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <h1 class="text-2xl font-semibold tracking-tight text-slate-900">
                 {{ __('Panel de control') }}
-            </h2>
-            <span class="inline-flex items-center text-sm text-gray-500">
+            </h1>
+            <p class="text-sm text-slate-500">
                 {{ $mostrandoGlobal ? __('Mostrando métricas globales') : __('Métricas filtradas por tu almacén asignado') }}
-            </span>
+            </p>
         </div>
     </x-slot>
 
@@ -69,78 +69,80 @@
         })->all();
     @endphp
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-8">
-            <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-                <x-dashboard.stat-card
-                    :title="__('Pedidos registrados')"
-                    :value="$formatNumber($totalesGenerales['total_pedidos'] ?? 0)"
-                    :subtitle="__('Pedidos capturados en el sistema')"
-                    icon="<svg xmlns='http://www.w3.org/2000/svg' class='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M3 7h18M3 12h18M3 17h18'/></svg>"
-                />
+    <section class="grid grid-cols-1 gap-6 md:grid-cols-2 2xl:grid-cols-4">
+        <x-tailadmin.metric-card
+            :title="__('Pedidos registrados')"
+            :value="$formatNumber($totalesGenerales['total_pedidos'] ?? 0)"
+            :subtitle="__('Pedidos capturados en el sistema')"
+            icon-classes="bg-indigo-100 text-indigo-600"
+            icon="<svg xmlns='http://www.w3.org/2000/svg' class='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M3 7h18M3 12h18M3 17h18'/></svg>"
+        />
 
-                <x-dashboard.stat-card
-                    :title="__('Monto total')"
-                    :value="$formatCurrency($totalesGenerales['monto_total'] ?? 0)"
-                    :subtitle="__('Ingresos esperados por pedidos')"
-                    icon="<svg xmlns='http://www.w3.org/2000/svg' class='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M12 8c-2.21 0-4 1.343-4 3s1.79 3 4 3 4 1.343 4 3-1.79 3-4 3m0-12c2.21 0 4 1.343 4 3m-4-3V4m0 16v-2'/></svg>"
-                />
+        <x-tailadmin.metric-card
+            :title="__('Monto total')"
+            :value="$formatCurrency($totalesGenerales['monto_total'] ?? 0)"
+            :subtitle="__('Ingresos esperados por pedidos')"
+            icon-classes="bg-emerald-100 text-emerald-600"
+            icon="<svg xmlns='http://www.w3.org/2000/svg' class='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M12 8c-2.21 0-4 1.343-4 3s1.79 3 4 3 4 1.343 4 3-1.79 3-4 3m0-12c2.21 0 4 1.343 4 3m-4-3V4m0 16v-2'/></svg>"
+        />
 
-                <x-dashboard.stat-card
-                    :title="__('Monto cobrado')"
-                    :value="$formatCurrency($totalesGenerales['monto_pagado'] ?? 0)"
-                    :subtitle="__('Pagos aplicados a pedidos')"
-                    icon="<svg xmlns='http://www.w3.org/2000/svg' class='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M9 12l2 2 4-4m4.5 2a9.5 9.5 0 11-19 0 9.5 9.5 0 0119 0z'/></svg>"
-                />
+        <x-tailadmin.metric-card
+            :title="__('Monto cobrado')"
+            :value="$formatCurrency($totalesGenerales['monto_pagado'] ?? 0)"
+            :subtitle="__('Pagos aplicados a pedidos')"
+            icon-classes="bg-sky-100 text-sky-600"
+            icon="<svg xmlns='http://www.w3.org/2000/svg' class='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M9 12l2 2 4-4m4.5 2a9.5 9.5 0 11-19 0 9.5 9.5 0 0119 0z'/></svg>"
+        />
 
-                <x-dashboard.stat-card
-                    :title="__('Saldo pendiente')"
-                    :value="$formatCurrency(($totalesGenerales['monto_total'] ?? 0) - ($totalesGenerales['monto_pagado'] ?? 0))"
-                    :subtitle="__('Importe restante por cobrar')"
-                    icon="<svg xmlns='http://www.w3.org/2000/svg' class='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M12 6v6l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'/></svg>"
-                />
-            </div>
+        <x-tailadmin.metric-card
+            :title="__('Saldo pendiente')"
+            :value="$formatCurrency(($totalesGenerales['monto_total'] ?? 0) - ($totalesGenerales['monto_pagado'] ?? 0))"
+            :subtitle="__('Importe restante por cobrar')"
+            icon-classes="bg-amber-100 text-amber-600"
+            icon="<svg xmlns='http://www.w3.org/2000/svg' class='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M12 6v6l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'/></svg>"
+        />
+    </section>
 
-            <div class="grid gap-6 lg:grid-cols-2">
-                <x-dashboard.status-table
-                    :title="__('Pedidos por estado')"
-                    :rows="$pedidosRows"
-                    :columns="[
-                        ['key' => 'total', 'label' => __('Pedidos'), 'class' => 'text-right', 'headerClass' => 'text-right'],
-                        ['key' => 'monto_total', 'label' => __('Monto total'), 'class' => 'text-right', 'headerClass' => 'text-right'],
-                        ['key' => 'monto_pagado', 'label' => __('Monto cobrado'), 'class' => 'text-right', 'headerClass' => 'text-right'],
-                        ['key' => 'saldo', 'label' => __('Saldo pendiente'), 'class' => 'text-right', 'headerClass' => 'text-right'],
-                    ]"
-                >
-                    {{ __('Estados consolidados de los pedidos registrados.') }}
-                </x-dashboard.status-table>
+    <section class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <x-tailadmin.data-table-card
+            :title="__('Pedidos por estado')"
+            :rows="$pedidosRows"
+            :columns="[
+                ['key' => 'total', 'label' => __('Pedidos'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                ['key' => 'monto_total', 'label' => __('Monto total'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                ['key' => 'monto_pagado', 'label' => __('Monto cobrado'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                ['key' => 'saldo', 'label' => __('Saldo pendiente'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+            ]"
+        >
+            {{ __('Estados consolidados de los pedidos registrados.') }}
+        </x-tailadmin.data-table-card>
 
-                <x-dashboard.status-table
-                    :title="__('Resumen de pagos')"
-                    :rows="$pagosRows"
-                    :columns="[
-                        ['key' => 'total', 'label' => __('Cobros'), 'class' => 'text-right', 'headerClass' => 'text-right'],
-                        ['key' => 'monto', 'label' => __('Monto registrado'), 'class' => 'text-right', 'headerClass' => 'text-right'],
-                        ['key' => 'monto_pagado', 'label' => __('Monto pagado'), 'class' => 'text-right', 'headerClass' => 'text-right'],
-                        ['key' => 'saldo', 'label' => __('Saldo'), 'class' => 'text-right', 'headerClass' => 'text-right'],
-                    ]"
-                >
-                    {{ __('Detalle de cobros pendientes y completados según estado de pago.') }}
-                </x-dashboard.status-table>
-            </div>
+        <x-tailadmin.data-table-card
+            :title="__('Resumen de pagos')"
+            :rows="$pagosRows"
+            :columns="[
+                ['key' => 'total', 'label' => __('Cobros'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                ['key' => 'monto', 'label' => __('Monto registrado'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                ['key' => 'monto_pagado', 'label' => __('Monto pagado'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                ['key' => 'saldo', 'label' => __('Saldo'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+            ]"
+        >
+            {{ __('Detalle de cobros pendientes y completados según estado de pago.') }}
+        </x-tailadmin.data-table-card>
+    </section>
 
-            <x-dashboard.status-table
-                :title="$mostrandoGlobal ? __('Rendimiento por almacén') : __('Resumen de tu almacén')"
-                :rows="$almacenRows"
-                :columns="[
-                    ['key' => 'total', 'label' => __('Pedidos'), 'class' => 'text-right', 'headerClass' => 'text-right'],
-                    ['key' => 'monto_total', 'label' => __('Monto total'), 'class' => 'text-right', 'headerClass' => 'text-right'],
-                    ['key' => 'monto_pagado', 'label' => __('Monto cobrado'), 'class' => 'text-right', 'headerClass' => 'text-right'],
-                    ['key' => 'saldo', 'label' => __('Saldo pendiente'), 'class' => 'text-right', 'headerClass' => 'text-right'],
-                ]"
-            >
-                {{ $mostrandoGlobal ? __('Comparativo de desempeño entre almacenes.') : __('Detalle de movimientos del almacén asignado.') }}
-            </x-dashboard.status-table>
-        </div>
-    </div>
+    <section>
+        <x-tailadmin.data-table-card
+            :title="$mostrandoGlobal ? __('Rendimiento por almacén') : __('Resumen de tu almacén')"
+            :rows="$almacenRows"
+            :columns="[
+                ['key' => 'total', 'label' => __('Pedidos'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                ['key' => 'monto_total', 'label' => __('Monto total'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                ['key' => 'monto_pagado', 'label' => __('Monto cobrado'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+                ['key' => 'saldo', 'label' => __('Saldo pendiente'), 'class' => 'text-right', 'headerClass' => 'text-right'],
+            ]"
+        >
+            {{ $mostrandoGlobal ? __('Comparativo de desempeño entre almacenes.') : __('Detalle de movimientos del almacén asignado.') }}
+        </x-tailadmin.data-table-card>
+    </section>
 </x-app-layout>

--- a/resources/views/pedidos/index.blade.php
+++ b/resources/views/pedidos/index.blade.php
@@ -1,81 +1,114 @@
 <x-app-layout>
     <x-slot name="header">
-        <div class="flex items-center justify-between">
-            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h1 class="text-2xl font-semibold tracking-tight text-slate-900">
                 {{ __('Pedidos') }}
-            </h2>
+            </h1>
             @can('manage pedidos')
-                <a href="{{ route('supervisor.pedidos.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:outline-none focus:border-indigo-700 focus:ring ring-indigo-200 transition ease-in-out duration-150">
+                <a href="{{ route('supervisor.pedidos.create') }}"
+                    class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
                     {{ __('Registrar pedido') }}
                 </a>
             @endcan
         </div>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900 space-y-4">
-                    @if (session('status'))
-                        <div class="rounded-md bg-green-50 p-4 text-sm text-green-700">{{ session('status') }}</div>
-                    @endif
+    <section class="space-y-6">
+        @if (session('status'))
+            <x-tailadmin.alert type="success">
+                {{ session('status') }}
+            </x-tailadmin.alert>
+        @endif
 
-                    <div class="overflow-x-auto">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-gray-50">
-                                <tr>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Código') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Tienda') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Vendedor') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Monto total') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Estado pago') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Estado pedido') }}</th>
-                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Acciones') }}</th>
-                                </tr>
-                            </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
-                                @forelse ($pedidos as $pedido)
-                                    <tr>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">#{{ $pedido->id }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $pedido->tienda?->nombre }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $pedido->vendedor?->nombre }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">S/ {{ number_format($pedido->monto_total, 2) }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm">
-                                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold {{ $pedido->estado_pago === \App\Models\Pedido::ESTADO_PAGO_PAGADO ? 'bg-green-100 text-green-800' : ($pedido->estado_pago === \App\Models\Pedido::ESTADO_PAGO_VUELTO ? 'bg-blue-100 text-blue-800' : 'bg-yellow-100 text-yellow-800') }}">
-                                                {{ __(ucwords(str_replace('_', ' ', $pedido->estado_pago))) }}
-                                            </span>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm">
-                                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold {{ $pedido->estado_pedido === \App\Models\Pedido::ESTADO_PEDIDO_ENTREGADO ? 'bg-green-100 text-green-800' : ($pedido->estado_pedido === \App\Models\Pedido::ESTADO_PEDIDO_ANULADO ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-800') }}">
-                                                {{ __(ucwords(str_replace('_', ' ', $pedido->estado_pedido))) }}
-                                            </span>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
-                                            <a href="{{ route('supervisor.pedidos.show', $pedido) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Ver') }}</a>
-                                            @can('manage pedidos')
-                                                <a href="{{ route('supervisor.pedidos.edit', $pedido) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('Editar') }}</a>
-                                                <form action="{{ route('supervisor.pedidos.destroy', $pedido) }}" method="POST" class="inline" onsubmit="return confirm('{{ __('¿Eliminar este pedido?') }}');">
-                                                    @csrf
-                                                    @method('DELETE')
-                                                    <button type="submit" class="text-red-600 hover:text-red-800">{{ __('Eliminar') }}</button>
-                                                </form>
-                                            @endcan
-                                        </td>
-                                    </tr>
-                                @empty
-                                    <tr>
-                                        <td colspan="7" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No se encontraron pedidos.') }}</td>
-                                    </tr>
-                                @endforelse
-                            </tbody>
-                        </table>
-                    </div>
+        @php
+            $estadoPagoStyles = [
+                \App\Models\Pedido::ESTADO_PAGO_PAGADO => 'bg-emerald-50 text-emerald-600 ring-emerald-100',
+                \App\Models\Pedido::ESTADO_PAGO_VUELTO => 'bg-sky-50 text-sky-600 ring-sky-100',
+                \App\Models\Pedido::ESTADO_PAGO_POR_COBRAR => 'bg-amber-50 text-amber-600 ring-amber-100',
+                \App\Models\Pedido::ESTADO_PAGO_PENDIENTE => 'bg-amber-50 text-amber-600 ring-amber-100',
+            ];
 
-                    <div>
-                        {{ $pedidos->links() }}
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+            $estadoPedidoStyles = [
+                \App\Models\Pedido::ESTADO_PEDIDO_ENTREGADO => 'bg-emerald-50 text-emerald-600 ring-emerald-100',
+                \App\Models\Pedido::ESTADO_PEDIDO_EN_CURSO => 'bg-sky-50 text-sky-600 ring-sky-100',
+                \App\Models\Pedido::ESTADO_PEDIDO_PENDIENTE => 'bg-amber-50 text-amber-600 ring-amber-100',
+                \App\Models\Pedido::ESTADO_PEDIDO_ANULADO => 'bg-rose-50 text-rose-600 ring-rose-100',
+            ];
+        @endphp
+
+        <x-tailadmin.table-card
+            :title="__('Pedidos registrados')"
+            :description="__('Consulta y gestiona los pedidos capturados en el sistema.')"
+            :headers="[
+                ['label' => __('Código')],
+                ['label' => __('Tienda')],
+                ['label' => __('Vendedor')],
+                ['label' => __('Monto total')],
+                ['label' => __('Estado pago')],
+                ['label' => __('Estado pedido')],
+                ['label' => __('Acciones'), 'class' => 'text-right'],
+            ]"
+        >
+            @forelse ($pedidos as $pedido)
+                <tr class="odd:bg-white even:bg-slate-50">
+                    <td class="whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-900">#{{ $pedido->id }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">{{ $pedido->tienda?->nombre }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">{{ $pedido->vendedor?->nombre }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">S/ {{ number_format($pedido->monto_total, 2) }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm">
+                        @php
+                            $estadoPagoClass = $estadoPagoStyles[$pedido->estado_pago] ?? 'bg-slate-50 text-slate-600 ring-slate-100';
+                        @endphp
+                        <span class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ring-inset {{ $estadoPagoClass }}">
+                            {{ __(ucwords(str_replace('_', ' ', $pedido->estado_pago))) }}
+                        </span>
+                    </td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm">
+                        @php
+                            $estadoPedidoClass = $estadoPedidoStyles[$pedido->estado_pedido] ?? 'bg-slate-50 text-slate-600 ring-slate-100';
+                        @endphp
+                        <span class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ring-inset {{ $estadoPedidoClass }}">
+                            {{ __(ucwords(str_replace('_', ' ', $pedido->estado_pedido))) }}
+                        </span>
+                    </td>
+                    <td class="whitespace-nowrap px-6 py-4 text-right text-sm">
+                        <div class="flex items-center justify-end gap-2">
+                            <a href="{{ route('supervisor.pedidos.show', $pedido) }}"
+                                class="inline-flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2">
+                                {{ __('Ver') }}
+                            </a>
+                            @can('manage pedidos')
+                                <a href="{{ route('supervisor.pedidos.edit', $pedido) }}"
+                                    class="inline-flex items-center gap-1 rounded-lg border border-indigo-200 bg-white px-3 py-1.5 text-sm font-medium text-indigo-600 shadow-sm transition hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                                    {{ __('Editar') }}
+                                </a>
+                                <form action="{{ route('supervisor.pedidos.destroy', $pedido) }}" method="POST"
+                                    class="inline"
+                                    onsubmit="return confirm('{{ __('¿Eliminar este pedido?') }}');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit"
+                                        class="inline-flex items-center gap-1 rounded-lg border border-rose-200 bg-white px-3 py-1.5 text-sm font-medium text-rose-600 shadow-sm transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-offset-2">
+                                        {{ __('Eliminar') }}
+                                    </button>
+                                </form>
+                            @endcan
+                        </div>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="7" class="px-6 py-4 text-center text-sm text-slate-500">
+                        {{ __('No se encontraron pedidos.') }}
+                    </td>
+                </tr>
+            @endforelse
+
+            @if ($pedidos->hasPages())
+                <x-slot:footer>
+                    {{ $pedidos->links() }}
+                </x-slot:footer>
+            @endif
+        </x-tailadmin.table-card>
+    </section>
 </x-app-layout>

--- a/resources/views/productos/index.blade.php
+++ b/resources/views/productos/index.blade.php
@@ -1,88 +1,85 @@
 <x-app-layout>
     <x-slot name="header">
-        <div class="flex items-center justify-between">
-            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h1 class="text-2xl font-semibold tracking-tight text-slate-900">
                 {{ __('Productos') }}
-            </h2>
+            </h1>
             @can('manage productos')
                 <a href="{{ route('productos.create') }}"
-                    class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                    class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
                     {{ __('Agregar producto') }}
                 </a>
             @endcan
         </div>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900 space-y-4">
-                    @if (session('status'))
-                        <div class="rounded-md bg-green-50 p-4 text-sm text-green-700">{{ session('status') }}</div>
-                    @endif
+    <section class="space-y-6">
+        @if (session('status'))
+            <x-tailadmin.alert type="success">
+                {{ session('status') }}
+            </x-tailadmin.alert>
+        @endif
 
-                    <div class="overflow-x-auto">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-gray-50">
-                                <tr>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Nombre') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Categoría') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Unidad') }}</th>
-                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Precio') }}</th>
-                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Acciones') }}</th>
-                                </tr>
-                            </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
-                                @forelse ($productos as $producto)
-                                    <tr>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                                            <a href="{{ route('productos.show', $producto) }}" class="text-indigo-600 hover:text-indigo-900">
-                                                {{ $producto->nombre }}
-                                            </a>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                                            {{ $producto->categoria?->nombre ?? __('Sin categoría') }}
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                                            {{ ucfirst($producto->unidad) }}
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">
-                                            S/ {{ number_format($producto->precio_referencial, 2) }}
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
-                                            @can('manage productos')
-                                                <div class="flex items-center justify-end gap-2">
-                                                    <a href="{{ route('productos.edit', $producto) }}"
-                                                        class="inline-flex items-center rounded-md border border-indigo-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-indigo-600 transition duration-150 ease-in-out hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-                                                        {{ __('Actualizar') }}
-                                                    </a>
-                                                    <form action="{{ route('productos.destroy', $producto) }}" method="POST"
-                                                        onsubmit="return confirm('{{ __('¿Eliminar este producto?') }}');">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type="submit"
-                                                            class="inline-flex items-center rounded-md border border-red-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-red-600 transition duration-150 ease-in-out hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
-                                                            {{ __('Eliminar') }}
-                                                        </button>
-                                                    </form>
-                                                </div>
-                                            @endcan
-                                        </td>
-                                    </tr>
-                                @empty
-                                    <tr>
-                                        <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No se encontraron productos.') }}</td>
-                                    </tr>
-                                @endforelse
-                            </tbody>
-                        </table>
-                    </div>
+        <x-tailadmin.table-card
+            :title="__('Productos disponibles')"
+            :description="__('Consulta el catálogo de productos y gestiona su información.')"
+            :headers="[
+                ['label' => __('Nombre')],
+                ['label' => __('Categoría')],
+                ['label' => __('Unidad')],
+                ['label' => __('Precio'), 'class' => 'text-right'],
+                ['label' => __('Acciones'), 'class' => 'text-right'],
+            ]"
+        >
+            @forelse ($productos as $producto)
+                <tr class="odd:bg-white even:bg-slate-50">
+                    <td class="whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-900">
+                        <a href="{{ route('productos.show', $producto) }}" class="text-indigo-600 transition hover:text-indigo-500">
+                            {{ $producto->nombre }}
+                        </a>
+                    </td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">
+                        {{ $producto->categoria?->nombre ?? __('Sin categoría') }}
+                    </td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">
+                        {{ ucfirst($producto->unidad) }}
+                    </td>
+                    <td class="whitespace-nowrap px-6 py-4 text-right text-sm text-slate-600">
+                        S/ {{ number_format($producto->precio_referencial, 2) }}
+                    </td>
+                    <td class="whitespace-nowrap px-6 py-4 text-right text-sm">
+                        @can('manage productos')
+                            <div class="flex items-center justify-end gap-2">
+                                <a href="{{ route('productos.edit', $producto) }}"
+                                    class="inline-flex items-center gap-2 rounded-lg border border-indigo-200 bg-white px-3 py-1.5 text-sm font-medium text-indigo-600 shadow-sm transition hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                                    {{ __('Actualizar') }}
+                                </a>
+                                <form action="{{ route('productos.destroy', $producto) }}" method="POST"
+                                    onsubmit="return confirm('{{ __('¿Eliminar este producto?') }}');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit"
+                                        class="inline-flex items-center gap-2 rounded-lg border border-rose-200 bg-white px-3 py-1.5 text-sm font-medium text-rose-600 shadow-sm transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-offset-2">
+                                        {{ __('Eliminar') }}
+                                    </button>
+                                </form>
+                            </div>
+                        @endcan
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="5" class="px-6 py-4 text-center text-sm text-slate-500">
+                        {{ __('No se encontraron productos.') }}
+                    </td>
+                </tr>
+            @endforelse
 
-                    <div>
-                        {{ $productos->links() }}
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+            @if ($productos->hasPages())
+                <x-slot:footer>
+                    {{ $productos->links() }}
+                </x-slot:footer>
+            @endif
+        </x-tailadmin.table-card>
+    </section>
 </x-app-layout>

--- a/resources/views/tiendas/index.blade.php
+++ b/resources/views/tiendas/index.blade.php
@@ -1,78 +1,77 @@
 <x-app-layout>
     <x-slot name="header">
-        <div class="flex items-center justify-between">
-            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h1 class="text-2xl font-semibold tracking-tight text-slate-900">
                 {{ __('Tiendas') }}
-            </h2>
+            </h1>
             @can('manage tiendas')
                 <a href="{{ route('tiendas.create') }}"
-                    class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                    class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
                     {{ __('Agregar tienda') }}
                 </a>
             @endcan
         </div>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900 space-y-4">
-                    @if (session('status'))
-                        <div class="rounded-md bg-green-50 p-4 text-sm text-green-700">{{ session('status') }}</div>
-                    @endif
+    <section class="space-y-6">
+        @if (session('status'))
+            <x-tailadmin.alert type="success">
+                {{ session('status') }}
+            </x-tailadmin.alert>
+        @endif
 
-                    <div class="overflow-x-auto">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-gray-50">
-                                <tr>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Nombre') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Sector') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Teléfono') }}</th>
-                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Acciones') }}</th>
-                                </tr>
-                            </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
-                                @forelse ($tiendas as $tienda)
-                                    <tr>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                                            <a href="{{ route('tiendas.show', $tienda) }}" class="text-indigo-600 hover:text-indigo-900">{{ $tienda->nombre }}</a>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $tienda->sector }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $tienda->telefono }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
-                                            @can('manage tiendas')
-                                                <div class="flex items-center justify-end gap-2">
-                                                    <a href="{{ route('tiendas.edit', $tienda) }}"
-                                                        class="inline-flex items-center rounded-md border border-indigo-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-indigo-600 transition duration-150 ease-in-out hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-                                                        {{ __('Actualizar') }}
-                                                    </a>
-                                                    <form action="{{ route('tiendas.destroy', $tienda) }}" method="POST"
-                                                        onsubmit="return confirm('{{ __('¿Eliminar esta tienda?') }}');">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type="submit"
-                                                            class="inline-flex items-center rounded-md border border-red-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-red-600 transition duration-150 ease-in-out hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
-                                                            {{ __('Eliminar') }}
-                                                        </button>
-                                                    </form>
-                                                </div>
-                                            @endcan
-                                        </td>
-                                    </tr>
-                                @empty
-                                    <tr>
-                                        <td colspan="4" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No se encontraron tiendas.') }}</td>
-                                    </tr>
-                                @endforelse
-                            </tbody>
-                        </table>
-                    </div>
+        <x-tailadmin.table-card
+            :title="__('Tiendas registradas')"
+            :description="__('Gestiona las tiendas disponibles y su información de contacto.')"
+            :headers="[
+                ['label' => __('Nombre')],
+                ['label' => __('Sector')],
+                ['label' => __('Teléfono')],
+                ['label' => __('Acciones'), 'class' => 'text-right'],
+            ]"
+        >
+            @forelse ($tiendas as $tienda)
+                <tr class="odd:bg-white even:bg-slate-50">
+                    <td class="whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-900">
+                        <a href="{{ route('tiendas.show', $tienda) }}" class="text-indigo-600 transition hover:text-indigo-500">
+                            {{ $tienda->nombre }}
+                        </a>
+                    </td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">{{ $tienda->sector }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">{{ $tienda->telefono }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-right text-sm">
+                        @can('manage tiendas')
+                            <div class="flex items-center justify-end gap-2">
+                                <a href="{{ route('tiendas.edit', $tienda) }}"
+                                    class="inline-flex items-center gap-2 rounded-lg border border-indigo-200 bg-white px-3 py-1.5 text-sm font-medium text-indigo-600 shadow-sm transition hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                                    {{ __('Actualizar') }}
+                                </a>
+                                <form action="{{ route('tiendas.destroy', $tienda) }}" method="POST"
+                                    onsubmit="return confirm('{{ __('¿Eliminar esta tienda?') }}');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit"
+                                        class="inline-flex items-center gap-2 rounded-lg border border-rose-200 bg-white px-3 py-1.5 text-sm font-medium text-rose-600 shadow-sm transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-offset-2">
+                                        {{ __('Eliminar') }}
+                                    </button>
+                                </form>
+                            </div>
+                        @endcan
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="4" class="px-6 py-4 text-center text-sm text-slate-500">
+                        {{ __('No se encontraron tiendas.') }}
+                    </td>
+                </tr>
+            @endforelse
 
-                    <div>
-                        {{ $tiendas->links() }}
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+            @if ($tiendas->hasPages())
+                <x-slot:footer>
+                    {{ $tiendas->links() }}
+                </x-slot:footer>
+            @endif
+        </x-tailadmin.table-card>
+    </section>
 </x-app-layout>

--- a/resources/views/vendedores/index.blade.php
+++ b/resources/views/vendedores/index.blade.php
@@ -1,78 +1,77 @@
 <x-app-layout>
     <x-slot name="header">
-        <div class="flex items-center justify-between">
-            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h1 class="text-2xl font-semibold tracking-tight text-slate-900">
                 {{ __('Vendedores') }}
-            </h2>
+            </h1>
             @can('manage vendedores')
                 <a href="{{ route('vendedores.create') }}"
-                    class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                    class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
                     {{ __('Agregar vendedor') }}
                 </a>
             @endcan
         </div>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900 space-y-4">
-                    @if (session('status'))
-                        <div class="rounded-md bg-green-50 p-4 text-sm text-green-700">{{ session('status') }}</div>
-                    @endif
+    <section class="space-y-6">
+        @if (session('status'))
+            <x-tailadmin.alert type="success">
+                {{ session('status') }}
+            </x-tailadmin.alert>
+        @endif
 
-                    <div class="overflow-x-auto">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-gray-50">
-                                <tr>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Nombre') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Tienda') }}</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Teléfono') }}</th>
-                                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Acciones') }}</th>
-                                </tr>
-                            </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
-                                @forelse ($vendedores as $vendedor)
-                                    <tr>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                                            <a href="{{ route('vendedores.show', $vendedor) }}" class="text-indigo-600 hover:text-indigo-900">{{ $vendedor->nombre }}</a>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $vendedor->tienda?->nombre ?? __('Sin tienda') }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $vendedor->telefono }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
-                                            @can('manage vendedores')
-                                                <div class="flex items-center justify-end gap-2">
-                                                    <a href="{{ route('vendedores.edit', $vendedor) }}"
-                                                        class="inline-flex items-center rounded-md border border-indigo-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-indigo-600 transition duration-150 ease-in-out hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-                                                        {{ __('Actualizar') }}
-                                                    </a>
-                                                    <form action="{{ route('vendedores.destroy', $vendedor) }}" method="POST"
-                                                        onsubmit="return confirm('{{ __('¿Eliminar este vendedor?') }}');">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type="submit"
-                                                            class="inline-flex items-center rounded-md border border-red-200 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-widest text-red-600 transition duration-150 ease-in-out hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
-                                                            {{ __('Eliminar') }}
-                                                        </button>
-                                                    </form>
-                                                </div>
-                                            @endcan
-                                        </td>
-                                    </tr>
-                                @empty
-                                    <tr>
-                                        <td colspan="4" class="px-6 py-4 text-center text-sm text-gray-500">{{ __('No se encontraron vendedores.') }}</td>
-                                    </tr>
-                                @endforelse
-                            </tbody>
-                        </table>
-                    </div>
+        <x-tailadmin.table-card
+            :title="__('Vendedores registrados')"
+            :description="__('Controla los vendedores y su asignación de tiendas.')"
+            :headers="[
+                ['label' => __('Nombre')],
+                ['label' => __('Tienda')],
+                ['label' => __('Teléfono')],
+                ['label' => __('Acciones'), 'class' => 'text-right'],
+            ]"
+        >
+            @forelse ($vendedores as $vendedor)
+                <tr class="odd:bg-white even:bg-slate-50">
+                    <td class="whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-900">
+                        <a href="{{ route('vendedores.show', $vendedor) }}" class="text-indigo-600 transition hover:text-indigo-500">
+                            {{ $vendedor->nombre }}
+                        </a>
+                    </td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">{{ $vendedor->tienda?->nombre ?? __('Sin tienda') }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">{{ $vendedor->telefono }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-right text-sm">
+                        @can('manage vendedores')
+                            <div class="flex items-center justify-end gap-2">
+                                <a href="{{ route('vendedores.edit', $vendedor) }}"
+                                    class="inline-flex items-center gap-2 rounded-lg border border-indigo-200 bg-white px-3 py-1.5 text-sm font-medium text-indigo-600 shadow-sm transition hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                                    {{ __('Actualizar') }}
+                                </a>
+                                <form action="{{ route('vendedores.destroy', $vendedor) }}" method="POST"
+                                    onsubmit="return confirm('{{ __('¿Eliminar este vendedor?') }}');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit"
+                                        class="inline-flex items-center gap-2 rounded-lg border border-rose-200 bg-white px-3 py-1.5 text-sm font-medium text-rose-600 shadow-sm transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-offset-2">
+                                        {{ __('Eliminar') }}
+                                    </button>
+                                </form>
+                            </div>
+                        @endcan
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="4" class="px-6 py-4 text-center text-sm text-slate-500">
+                        {{ __('No se encontraron vendedores.') }}
+                    </td>
+                </tr>
+            @endforelse
 
-                    <div>
-                        {{ $vendedores->links() }}
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+            @if ($vendedores->hasPages())
+                <x-slot:footer>
+                    {{ $vendedores->links() }}
+                </x-slot:footer>
+            @endif
+        </x-tailadmin.table-card>
+    </section>
 </x-app-layout>


### PR DESCRIPTION
## Summary
- replace the dashboard view to use TailAdmin metric and data table cards
- add reusable TailAdmin alert, table, and section card Blade components and drop the old dashboard components
- restyle module index screens (tiendas, vendedores, productos, categorías, pedidos, almacén y cierres) plus admin listings to align with the new layout

## Testing
- `php artisan test` *(fails: vendor autoload missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de40a2093c8321b01aac6de3cb45cc