### PR TITLE
Refine TailAdmin blade slots

### DIFF
--- a/resources/views/components/tailadmin/data-table-card.blade.php
+++ b/resources/views/components/tailadmin/data-table-card.blade.php
@@ -6,10 +6,8 @@
 ])
 
 @php
-    use Illuminate\\View\\ComponentSlot;
-
     $hasDescription = ! $slot->isEmpty();
-    $hasActions = isset($actions) && $actions instanceof ComponentSlot && trim($actions->toHtml()) !== '';
+    $hasActions = isset($actions) && $actions instanceof \Illuminate\View\ComponentSlot && trim($actions->toHtml()) !== '';
 @endphp
 
 <div

--- a/resources/views/components/tailadmin/metric-card.blade.php
+++ b/resources/views/components/tailadmin/metric-card.blade.php
@@ -9,12 +9,10 @@
 ])
 
 @php
-    use Illuminate\\View\\ComponentSlot;
-
-    $iconContent = $icon instanceof ComponentSlot ? $icon->toHtml() : $icon;
+    $iconContent = $icon instanceof \Illuminate\View\ComponentSlot ? $icon->toHtml() : $icon;
     $hasIcon = filled(trim((string) ($iconContent ?? '')));
 
-    $badgeContent = $badge instanceof ComponentSlot ? $badge->toHtml() : $badge;
+    $badgeContent = $badge instanceof \Illuminate\View\ComponentSlot ? $badge->toHtml() : $badge;
     $hasBadge = filled(trim((string) ($badgeContent ?? '')));
 
     $badgePalettes = [

--- a/resources/views/components/tailadmin/section-card.blade.php
+++ b/resources/views/components/tailadmin/section-card.blade.php
@@ -4,10 +4,8 @@
 ])
 
 @php
-    use Illuminate\\View\\ComponentSlot;
-
-    $hasActions = isset($actions) && $actions instanceof ComponentSlot && trim($actions->toHtml()) !== '';
-    $hasFooter = isset($footer) && $footer instanceof ComponentSlot && trim($footer->toHtml()) !== '';
+    $hasActions = isset($actions) && $actions instanceof \Illuminate\View\ComponentSlot && trim($actions->toHtml()) !== '';
+    $hasFooter = isset($footer) && $footer instanceof \Illuminate\View\ComponentSlot && trim($footer->toHtml()) !== '';
 @endphp
 
 <div

--- a/resources/views/components/tailadmin/table-card.blade.php
+++ b/resources/views/components/tailadmin/table-card.blade.php
@@ -5,11 +5,9 @@
 ])
 
 @php
-    use Illuminate\\View\\ComponentSlot;
-
     $hasDescription = filled($description);
-    $hasActions = isset($actions) && $actions instanceof ComponentSlot && trim($actions->toHtml()) !== '';
-    $hasFooter = isset($footer) && $footer instanceof ComponentSlot && trim($footer->toHtml()) !== '';
+    $hasActions = isset($actions) && $actions instanceof \Illuminate\View\ComponentSlot && trim($actions->toHtml()) !== '';
+    $hasFooter = isset($footer) && $footer instanceof \Illuminate\View\ComponentSlot && trim($footer->toHtml()) !== '';
 @endphp
 
 <div


### PR DESCRIPTION
## Summary
- remove redundant ComponentSlot imports from TailAdmin Blade components
- use fully qualified \Illuminate\View\ComponentSlot references when checking slot instances

## Testing
- php artisan view:clear

------
https://chatgpt.com/codex/tasks/task_e_68df179efa6c832192d6d2920493eb9c