### PR TITLE
Validate cierres filters and normalize date handling

### DIFF
--- a/app/Http/Controllers/CierreAlmacenController.php
+++ b/app/Http/Controllers/CierreAlmacenController.php
@@ -7,13 +7,29 @@ use App\Models\Pedido;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
+use Throwable;
 
 class CierreAlmacenController extends Controller
 {
     public function index(Request $request): View
     {
-        $fecha = $request->input('fecha');
-        $almacenId = $request->input('almacen_id');
+        $validated = $request->validate([
+            'fecha' => ['nullable', 'date_format:Y-m-d'],
+            'almacen_id' => ['nullable', 'integer', 'exists:almacenes,id'],
+        ]);
+
+        $fechaInput = $validated['fecha'] ?? null;
+        $almacenId = $validated['almacen_id'] ?? null;
+
+        $fecha = null;
+
+        if ($fechaInput !== null) {
+            try {
+                $fecha = Carbon::createFromFormat('Y-m-d', $fechaInput);
+            } catch (Throwable $exception) {
+                $fecha = null;
+            }
+        }
 
         $cierres = Pedido::query()
             ->selectRaw('DATE(pedidos.created_at) as fecha')
@@ -24,12 +40,23 @@ class CierreAlmacenController extends Controller
             ->selectRaw('SUM(CASE WHEN pedidos.monto_pagado > pedidos.monto_total THEN pedidos.monto_pagado - pedidos.monto_total ELSE 0 END) as total_vuelto')
             ->leftJoin('almacenes', 'almacenes.id', '=', 'pedidos.almacen_id')
             ->addSelect('almacenes.nombre as almacen_nombre')
-            ->when($fecha, fn ($query) => $query->whereDate('pedidos.created_at', Carbon::parse($fecha)))
+            ->when($fecha, fn ($query) => $query->whereDate('pedidos.created_at', $fecha))
             ->when($almacenId, fn ($query) => $query->where('pedidos.almacen_id', $almacenId))
             ->groupBy('fecha', 'pedidos.almacen_id', 'almacenes.nombre')
             ->orderByDesc('fecha')
             ->orderBy('almacenes.nombre')
-            ->paginate(15);
+            ->paginate(15)
+            ->through(function ($cierre) {
+                if (! empty($cierre->fecha)) {
+                    try {
+                        $cierre->fecha = Carbon::createFromFormat('Y-m-d', (string) $cierre->fecha);
+                    } catch (Throwable $exception) {
+                        $cierre->fecha = null;
+                    }
+                }
+
+                return $cierre;
+            });
 
         $almacenes = Almacen::orderBy('nombre')->pluck('nombre', 'id');
 

--- a/resources/views/cierres/index.blade.php
+++ b/resources/views/cierres/index.blade.php
@@ -13,7 +13,13 @@
             <form method="GET" class="grid grid-cols-1 items-end gap-4 md:grid-cols-4">
                 <div>
                     <x-input-label for="fecha" value="{{ __('Fecha') }}" />
-                    <x-text-input id="fecha" type="date" name="fecha" class="mt-1 block w-full" :value="$fecha" />
+                    <x-text-input
+                        id="fecha"
+                        type="date"
+                        name="fecha"
+                        class="mt-1 block w-full"
+                        :value="$fecha?->toDateString()"
+                    />
                 </div>
                 <div>
                     <x-input-label for="almacen_id" value="{{ __('Almacén') }}" />
@@ -52,7 +58,7 @@
         >
             @forelse ($cierres as $cierre)
                 <tr class="odd:bg-white even:bg-slate-50">
-                    <td class="whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-900">{{ \Carbon\Carbon::parse($cierre->fecha)->format('d/m/Y') }}</td>
+                    <td class="whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-900">{{ optional($cierre->fecha)->format('d/m/Y') }}</td>
                     <td class="whitespace-nowrap px-6 py-4 text-sm text-slate-600">{{ $cierre->almacen_nombre ?? __('Sin almacén') }}</td>
                     <td class="whitespace-nowrap px-6 py-4 text-right text-sm text-slate-700">S/ {{ number_format($cierre->total_monto, 2) }}</td>
                     <td class="whitespace-nowrap px-6 py-4 text-right text-sm text-slate-700">S/ {{ number_format($cierre->total_pagado, 2) }}</td>

--- a/tests/Feature/CierreAlmacenControllerTest.php
+++ b/tests/Feature/CierreAlmacenControllerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Almacen;
+use App\Models\Pedido;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class CierreAlmacenControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Role $supervisorRole;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        $permission = Permission::firstOrCreate([
+            'name' => 'view cierres',
+            'guard_name' => 'web',
+        ]);
+
+        $this->supervisorRole = Role::firstOrCreate([
+            'name' => 'Supervisor',
+            'guard_name' => 'web',
+        ]);
+
+        $this->supervisorRole->syncPermissions([$permission]);
+    }
+
+    protected function actingAsSupervisor(): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole($this->supervisorRole);
+
+        return $user;
+    }
+
+    public function test_index_returns_filtered_cierres_with_normalized_fecha(): void
+    {
+        $almacen = Almacen::factory()->create();
+        $otherAlmacen = Almacen::factory()->create();
+
+        $targetDate = Carbon::create(2024, 5, 1);
+
+        Pedido::factory()->create([
+            'almacen_id' => $almacen->id,
+            'created_at' => $targetDate->copy()->setTime(10, 30),
+            'monto_total' => 150,
+            'monto_pagado' => 100,
+            'saldo_pendiente' => 50,
+        ]);
+
+        Pedido::factory()->create([
+            'almacen_id' => $almacen->id,
+            'created_at' => $targetDate->copy()->setTime(15, 45),
+            'monto_total' => 50,
+            'monto_pagado' => 25,
+            'saldo_pendiente' => 25,
+        ]);
+
+        Pedido::factory()->create([
+            'almacen_id' => $otherAlmacen->id,
+            'created_at' => $targetDate->copy()->addDay()->setTime(9, 0),
+        ]);
+
+        $user = $this->actingAsSupervisor();
+
+        $response = $this->actingAs($user)->get(route('supervisor.cierres.index', [
+            'fecha' => $targetDate->toDateString(),
+            'almacen_id' => $almacen->id,
+        ]));
+
+        $response->assertOk();
+
+        $response->assertViewHas('fecha', function ($fecha) use ($targetDate) {
+            return $fecha instanceof Carbon && $fecha->isSameDay($targetDate);
+        });
+
+        $response->assertViewHas('almacenId', $almacen->id);
+
+        $cierres = $response->viewData('cierres');
+
+        $this->assertCount(1, $cierres);
+
+        $cierre = $cierres->first();
+
+        $this->assertInstanceOf(Carbon::class, $cierre->fecha);
+        $this->assertTrue($cierre->fecha->isSameDay($targetDate));
+        $this->assertEquals(200.0, (float) $cierre->total_monto);
+        $this->assertEquals(125.0, (float) $cierre->total_pagado);
+        $this->assertEquals(75.0, (float) $cierre->total_pendiente);
+    }
+
+    public function test_index_rejects_invalid_fecha(): void
+    {
+        $user = $this->actingAsSupervisor();
+
+        $indexRoute = route('supervisor.cierres.index');
+
+        $response = $this->actingAs($user)
+            ->from($indexRoute)
+            ->get(route('supervisor.cierres.index', ['fecha' => '2024-02-30']));
+
+        $response->assertRedirect($indexRoute);
+        $response->assertSessionHasErrors('fecha');
+    }
+
+    public function test_index_rejects_invalid_almacen_id(): void
+    {
+        $user = $this->actingAsSupervisor();
+
+        $indexRoute = route('supervisor.cierres.index');
+
+        $response = $this->actingAs($user)
+            ->from($indexRoute)
+            ->get(route('supervisor.cierres.index', ['almacen_id' => 9999]));
+
+        $response->assertRedirect($indexRoute);
+        $response->assertSessionHasErrors('almacen_id');
+    }
+}


### PR DESCRIPTION
## Summary
- validate fecha and almacen filters before building the cierres query
- normalize Carbon instances for filtering and presentation and update the view to consume them
- cover valid and invalid filter scenarios with new controller feature tests

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68df1a4285dc83219db7cefb76fad6e3