### PR TITLE
Add configurable label column header to TailAdmin data table

### DIFF
--- a/resources/views/components/tailadmin/data-table-card.blade.php
+++ b/resources/views/components/tailadmin/data-table-card.blade.php
@@ -2,6 +2,7 @@
     'title' => null,
     'rows' => [],
     'columns' => [],
+    'labelColumn' => __('Estado'),
     'emptyMessage' => 'No hay datos disponibles.',
 ])
 
@@ -46,7 +47,7 @@
                     <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
                         <tr>
                             <th scope="col" class="whitespace-nowrap px-6 py-3 text-left">
-                                {{ __('Estado') }}
+                                {{ $labelColumn }}
                             </th>
                             @foreach ($columns as $column)
                                 <th

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -106,6 +106,7 @@
     <section class="grid grid-cols-1 gap-6 xl:grid-cols-2">
         <x-tailadmin.data-table-card
             :title="__('Pedidos por estado')"
+            :label-column="__('Estado')"
             :rows="$pedidosRows"
             :columns="[
                 ['key' => 'total', 'label' => __('Pedidos'), 'class' => 'text-right', 'headerClass' => 'text-right'],
@@ -119,6 +120,7 @@
 
         <x-tailadmin.data-table-card
             :title="__('Resumen de pagos')"
+            :label-column="__('Estado de pago')"
             :rows="$pagosRows"
             :columns="[
                 ['key' => 'total', 'label' => __('Cobros'), 'class' => 'text-right', 'headerClass' => 'text-right'],
@@ -134,6 +136,7 @@
     <section>
         <x-tailadmin.data-table-card
             :title="$mostrandoGlobal ? __('Rendimiento por almacén') : __('Resumen de tu almacén')"
+            :label-column="__('Almacén')"
             :rows="$almacenRows"
             :columns="[
                 ['key' => 'total', 'label' => __('Pedidos'), 'class' => 'text-right', 'headerClass' => 'text-right'],


### PR DESCRIPTION
## Summary
- add a configurable `labelColumn` prop to the TailAdmin data table card component
- update dashboard tables to specify the appropriate first-column header for each dataset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df1c97680483219c891f9ac5bb11b8